### PR TITLE
config: complain if address is not supplied but add default port

### DIFF
--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -17,10 +17,13 @@ function init(config) {
     }
 
     es_urls = config.map(function(entry) {
+        if (! entry.address) {
+            throw new Error('config requires address');
+        }
         var url = Url.format({
             protocol: 'http',
             hostname: entry.address,
-            port: entry.port
+            port: entry.port || 9200
         });
 
         return {


### PR DESCRIPTION
Instead of silently accepting a missing address, throw an error
when loading the config.

However we can default the port to 9200 to make things simple.
