### PR TITLE
Fix head optimization

### DIFF
--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -1,5 +1,17 @@
 var optimizer = {
-    optimize_head: function() {
+    optimize_head: function(read, head, graph, optimization_info) {
+        if (optimization_info.type && optimization_info.type !== 'head') {
+            return false;
+        }
+
+        var limit = graph.node_get_option(head, 'arg');
+
+        if (optimization_info.hasOwnProperty('limit')) {
+            limit = Math.min(limit, optimization_info.limit);
+        }
+
+        optimization_info.type = 'head';
+        optimization_info.limit = limit;
         return true;
     }
 };


### PR DESCRIPTION
Keep up with https://github.com/juttle/juttle/pull/168. Just stole the `optimize_head` function from the test backend.

@demmer @VladVega 
