### PR TITLE
Catch ES window overflow errors

### DIFF
--- a/lib/es-errors.js
+++ b/lib/es-errors.js
@@ -7,12 +7,20 @@ var MissingField = Base.inherits(Error, {
     }
 });
 
+var WindowOverflow = Base.inherits(Error, {
+    initialize: function(limit) {
+        this.limit = limit;
+    }
+});
+
 var MissingIndex = Base.inherits(Error, {});
+
 
 var _MISSING_FIELD_PATTERN = /No field found for \[([^\]]+)\] in mapping/;
 var _GROOVY_PATTERN = /groovy_script_execution_exception/;
 var _MISSING_INDEX_PATTERN = /index_not_found_exception/;
 var _OLD_MISSING_INDEX_PATTERN = /IndexMissingException/; // pre-2.0
+var _WINDOW_OVERFLOW_PATTERN = /Result window is too large, from \+ size must be less than or equal to: \[([^\]]+)\] but was \[([^\]]+)\]./;
 
 function categorize_error(error) {
     var str = error.message;
@@ -22,9 +30,10 @@ function categorize_error(error) {
     }
 
     var groovy = str.match(_GROOVY_PATTERN);
+    var match;
     if (groovy) {
         var cause = JSON.parse(error.response).error.failed_shards[0].reason.caused_by.reason;
-        var match = cause.match(_MISSING_FIELD_PATTERN);
+        match = cause.match(_MISSING_FIELD_PATTERN);
         if (match) {
             return new MissingField(match[1]);
         }
@@ -34,11 +43,17 @@ function categorize_error(error) {
         return new MissingIndex();
     }
 
+    match = str.match(_WINDOW_OVERFLOW_PATTERN);
+    if (match) {
+        return new WindowOverflow(Number(match[2]));
+    }
+
     return null;
 }
 
 module.exports = {
     categorize_error: categorize_error,
     MissingField: MissingField,
+    WindowOverflow: WindowOverflow,
     MissingIndex: MissingIndex,
 };

--- a/lib/query-common.js
+++ b/lib/query-common.js
@@ -2,6 +2,7 @@ var Promise = require('bluebird');
 var _ = require('underscore');
 var request = Promise.promisifyAll(require('request'));
 request.async = Promise.promisify(request);
+var util = require('util');
 
 var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
 var errors = require('./es-errors');
@@ -60,6 +61,9 @@ function search(client, indices, body) {
                     hits: []
                 }
             };
+        } else if (categorized instanceof errors.WindowOverflow) {
+            var error_string = util.format('Tried to read more than %d points with the same timestamp, increase the max_result_window setting on the relevant indices to read more (performance may vary)', categorized.limit);
+            throw new Error(error_string);
         } else if (categorized) {
             throw categorized;
         } else {

--- a/test/elastic-adapter-limits.js
+++ b/test/elastic-adapter-limits.js
@@ -81,6 +81,32 @@ describe('elastic source limits', function() {
                     expect(result.prog.graph.es_opts.limit).equal(3);
                 });
             });
+
+            it('catches window errors and reports something usable', function() {
+                function set_window(size) {
+                    return request.putAsync({
+                        url: 'http://localhost:9200/logstash-*/_settings',
+                        json: {
+                            index: {
+                                max_result_window: size
+                            }
+                        }
+                    });
+                }
+
+                return set_window(100)
+                .spread(function(res, body) {
+                    var program = 'read elastic -from :10 years ago: -to :now:';
+                    return check_juttle({program: program});
+                })
+                .then(function(result) {
+                    var e = 'Tried to read more than 10000 points with the same timestamp, increase the max_result_window setting on the relevant indices to read more (performance may vary)';
+                    expect(result.errors).deep.equal([e]);
+                })
+                .finally(function() {
+                    return set_window(10000);
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
ES 1.X and 2.0 did this cool thing where you could page to arbitrary depth and it would crash. In ES 2.1, they've introduced a new index setting `max_result_window` which is if you try to page past there it'll return 500. The default `max_result_window` is a meager 10,000 which means that any bridge fetches will fail on a default ES 2.1 setup. It seems dicey to start hacking people's index settings though, so let's just return an error that tells them what's up when they hit this case instead of `received status code 500 from Elasticsearch`.
@demmer 