### PR TITLE
Rename backend to adapter

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
-Juttle Elasticsearch Backend
+Juttle Elasticsearch Adapter
 Copyright 2015 Jut, Inc.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# Juttle Elastic Backend
+# Juttle Elastic Adapter
 
-The Juttle Elastic Backend enables reading and writing documents using [Elasticsearch](https://www.elastic.co/products/elasticsearch). It supports the [Logstash](https://www.elastic.co/products/logstash) schema, so it can read any documents stored in Elasticsearch by Logstash.
+The Juttle Elastic Adapter enables reading and writing documents using [Elasticsearch](https://www.elastic.co/products/elasticsearch). It supports the [Logstash](https://www.elastic.co/products/logstash) schema, so it can read any documents stored in Elasticsearch by Logstash.
 
 ## Installation
 
 In your Juttle repo, execute:
 ```
-npm install juttle-elastic-backend
+npm install juttle-elastic-adapter
 ```
 
 ## Configuration
 
-The information in the Juttle repository documentation under `configuration` and `Configuring backends` will help setup a general Juttle Config.
+The information in the Juttle repository documentation under `configuration` and `Configuring adapters` will help setup a general Juttle Config.
 
-Configuration for the Elastic backend looks like this:
+Configuration for the Elastic adapter looks like this:
 ```
 {
-    "backends": {
+    "adapters": {
         "elastic": {
             "address": "localhost",
             "port": 9200

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 var Promise = require('bluebird');
 
 var Elastic = require('./elastic');
-function ESBackend(config, Juttle) {
+function ESAdapter(config, Juttle) {
     Elastic.init(config);
 
     return {
@@ -12,4 +12,4 @@ function ESBackend(config, Juttle) {
     };
 }
 
-module.exports = ESBackend;
+module.exports = ESAdapter;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "juttle-elastic-backend",
+  "name": "juttle-elastic-adapter",
   "version": "0.0.1",
   "description": "A plugin enabling Juttle computations on documents stored in Elastic",
   "main": "lib/index.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/juttle/elastic-backend.git"
+    "url": "https://github.com/juttle/juttle-elastic-adapter.git"
   },
   "keywords": [
     "juttle",
@@ -20,9 +20,9 @@
   "author": "Dave Galbraith",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/juttle/elastic-backend/issues"
+    "url": "https://github.com/juttle/juttle-elastic-adapter/issues"
   },
-  "homepage": "https://github.com/juttle/elastic-backend",
+  "homepage": "https://github.com/juttle/juttle-elastic-adapter/",
   "dependencies": {
     "bluebird": "^2.9.30",
     "bluebird-retry": "^0.5.2",

--- a/test/elastic-adapter-limits.js
+++ b/test/elastic-adapter-limits.js
@@ -10,7 +10,7 @@ var juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
 var check_juttle = juttle_test_utils.check_juttle;
 var points = require('./apache-sample');
 
-// Register the backend
+// Register the adapter
 require('./elastic-test-utils');
 
 var expected_points = points.map(function(pt) {

--- a/test/elastic-adapter.spec.js
+++ b/test/elastic-adapter.spec.js
@@ -16,7 +16,7 @@ var expected_points = points.map(function(pt) {
     return new_pt;
 });
 
-// Register the backend
+// Register the adapter
 require('./elastic-test-utils');
 
 describe('elastic source', function() {

--- a/test/elastic-test-utils.js
+++ b/test/elastic-test-utils.js
@@ -21,9 +21,9 @@ var config = [{
     port: 9999 // b's config is botched so we can get errors reading from it
 }];
 
-var backend = Elastic(config, Juttle);
+var adapter = Elastic(config, Juttle);
 
-Juttle.backends.register(backend.name, backend);
+Juttle.adapters.register(adapter.name, adapter);
 
 function clear_logstash_data() {
     return request.async({

--- a/test/optimization.spec.js
+++ b/test/optimization.spec.js
@@ -31,7 +31,7 @@ function format_juttle_result_like_es(pts) {
 var start = new Date(points[0].time).toISOString();
 var end = new Date(_.last(points).time+1).toISOString();
 
-// Register the backend
+// Register the adapter
 require('./elastic-test-utils');
 
 describe('optimization', function() {


### PR DESCRIPTION
Rename files, replace usage in code and docs.

refs https://github.com/juttle/juttle/pull/269
