### PR TITLE
Parallelize optimized requests

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -10,6 +10,7 @@ var es_errors = require('./es-errors');
 
 var DEFAULT_FETCH_SIZE;
 var DEFAULT_DEEP_PAGING_LIMIT;
+var DEFAULT_OPTIMIZED_REQUEST_CONCURRENCY;
 
 function make_body(filter, from, to, direction, tm_filter, size, timeField) {
     if (!tm_filter) {
@@ -184,8 +185,10 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
     var indices = options.indices;
     var type = options.type;
     var aggregations = options.aggregations;
-    var reduce_every = aggregations.reduce_every;
+    var reduce_every = aggregations.reduce_every ? new JuttleMoment.duration(aggregations.reduce_every) : null;
+    var grouped = aggregations.grouping && aggregations.grouping.length > 0;
     var timeField = options.timeField;
+    var concurrency = options.optimized_request_concurrency || DEFAULT_OPTIMIZED_REQUEST_CONCURRENCY;
 
     function get_batch_offset_as_duration(every_duration) {
         try {
@@ -206,22 +209,21 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
         // are just executed as though they were single-batch batch queries
         var buckets = [query_start];
         if (reduce_every) {
-            var duration = new JuttleMoment.duration(reduce_every);
-            var zeroth_bucket = JuttleMoment.quantize(query_start, duration);
-            var last_bucket = JuttleMoment.quantize(query_end, duration);
+            var zeroth_bucket = JuttleMoment.quantize(query_start, reduce_every);
+            var last_bucket = JuttleMoment.quantize(query_end, reduce_every);
 
             if (aggregations.reduce_on) {
-                var offset = get_batch_offset_as_duration(duration);
+                var offset = get_batch_offset_as_duration(reduce_every);
                 zeroth_bucket = JuttleMoment.add(zeroth_bucket, offset);
                 buckets.push(zeroth_bucket);
                 last_bucket = JuttleMoment.add(last_bucket, offset);
             }
 
-            var intermediate_bucket = JuttleMoment.add(zeroth_bucket, duration);
+            var intermediate_bucket = JuttleMoment.add(zeroth_bucket, reduce_every);
 
             while (intermediate_bucket.lte(last_bucket)) {
                 buckets.push(intermediate_bucket);
-                intermediate_bucket = JuttleMoment.add(intermediate_bucket, duration);
+                intermediate_bucket = JuttleMoment.add(intermediate_bucket, reduce_every);
             }
         }
 
@@ -231,12 +233,48 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
     }
 
     var buckets = get_buckets();
-    var has_emitted;
-    var buffered_empties = [];
+    var has_emitted, last_emitted_timestamp;
+
+    // if there are empty batches that fall between a pair of full batches
+    // we want to emit empty points. This function takes an array of all
+    // our full batches and fills in the gaps between them with empty batch
+    // points. It needs to be called after all `concurrency` requests are
+    // completed so we have all the full batch information
+    function fill_empties(points) {
+        // Juttle only creates empty results for non-grouped aggregations
+        if (grouped) {
+            return points;
+        }
+
+        // Past the first set of `concurrency` queries, if at least
+        // one of those batches was full, we may need to bridge a gap of
+        // empties between the first set of queries and the next.
+        // With this cheap trick we start filling empties from the end
+        // of the last set of requests
+        if (last_emitted_timestamp) {
+            points.unshift({time: last_emitted_timestamp});
+        }
+
+        var length = points.length;
+        for (var i = 0; i < length - 1; i++) {
+            var t1 = points[i].time;
+            var t2 = points[i+1].time;
+            var next_expected_time = t1 && reduce_every && t1.add(reduce_every);
+            if (next_expected_time && t2 && next_expected_time.milliseconds() < t2.milliseconds()) {
+                points.splice(i+1, 0, _.extend({time: next_expected_time}, aggregations.empty_result));
+                length++;
+            }
+        }
+
+        // get rid of the fake point we added before the for-loop
+        if (last_emitted_timestamp) {
+            points.shift();
+        }
+
+        return points;
+    }
 
     function fetcher() {
-        var grouped = aggregations.grouping && aggregations.grouping.length > 0;
-
         if (buckets.length === 0) {
             return Promise.resolve({
                 points: [],
@@ -244,78 +282,63 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
             });
         }
 
-        var from = buckets.shift();
-        var to = buckets[0];
-        if (!from || !to) {
-            throw new Error('aggregation fetcher didn\'t have from/to');
-        }
+        var current_buckets = buckets.splice(0, concurrency);
+        return Promise.map(current_buckets, function fetchBucket(from, i) {
+            var to = current_buckets[i+1] || buckets[0];
+            if (!to) {
+                return [];
+            }
 
-        var query_body = make_body(filter, from, to, 'asc', null, 0, timeField);
+            var query_body = make_body(filter, from, to, 'asc', null, 0, timeField);
 
-        query_body.aggregations = aggregations.es_aggr;
+            query_body.aggregations = aggregations.es_aggr;
 
-        return common.search(client, indices, type, query_body)
-        .then(function(response) {
-            var total = response.hits && response.hits.total;
-            if (total === 0 && !grouped) {
-                if (has_emitted) {
-                    var pt = {};
-                    if (reduce_every) {
+            return common.search(client, indices, type, query_body)
+            .then(function(response) {
+                var total = response.hits && response.hits.total;
+                if (total === 0) {
+                    return [];
+                }
+
+                var aggr_points = juttle_utils.toNative(aggregation.values_from_es_aggr_resp(response, aggregations));
+
+                if (reduce_every) {
+                    aggr_points.forEach(function(pt) {
+                        if (to === query_end) {
+                            to = JuttleMoment.quantize(to, reduce_every).add(reduce_every);
+                        }
                         pt.time = to;
-                    }
-
-                    buffered_empties.push(_.extend(pt, aggregations.empty_result));
+                    });
                 }
 
-                return {
-                    points: [],
-                    eof: buckets.length === 1
-                };
-            }
-
-            var aggr_points = juttle_utils.toNative(aggregation.values_from_es_aggr_resp(response, aggregations));
-
-            if (reduce_every) {
-                aggr_points.forEach(function(pt) {
-                    if (to === query_end) {
-                        var duration = new JuttleMoment.duration(reduce_every);
-                        to = JuttleMoment.quantize(to, duration).add(duration);
-                    }
-                    pt.time = to;
-                });
-            }
-
-            // If points are timeful, this aggregation included a date
-            // histogram, so we make the timestamps epsilon moments, just
-            // like they would be if they came out of reduce -every
-            if (_.has(aggr_points[0], 'time')) {
-                _.each (aggr_points, function(pt) { pt.time.epsilon = true; });
-            }
-
-            if (grouped) {
-                var limit = aggregations.es_aggr.group.terms.size;
-                if (aggr_points.length === limit || (response.aggregations &&
-                    response.aggregations.group &&
-                    response.aggregations.group.buckets &&
-                    response.aggregations.group.buckets.length === limit)) {
+                // If points are timeful, this aggregation included a date
+                // histogram, so we make the timestamps epsilon moments, just
+                // like they would be if they came out of reduce -every
+                if (_.has(aggr_points[0], 'time')) {
+                    _.each (aggr_points, function(pt) { pt.time.epsilon = true; });
                 }
-            }
 
-            var all_points = buffered_empties.concat(aggr_points);
-            buffered_empties = [];
-            has_emitted = true;
-            return {
-                eof: buckets.length === 1, // last bucket is exclusive
-                points: all_points
-            };
+                has_emitted = true;
+                return aggr_points;
+            })
+            .catch(es_errors.MissingField, function(ex) {
+                // our scripted aggregation will fail if we try to group
+                // by a non-existent field.  when this happens, remove
+                // the non-existent field and re-run the aggregation.
+                aggregations = aggregation.remove_field(aggregations, ex.name);
+                return fetchBucket(from, i);
+            });
         })
-        .catch(es_errors.MissingField, function(ex) {
-            // our scripted aggregation will fail if we try to group
-            // by a non-existent field.  when this happens, remove
-            // the non-existent field and re-run the aggregation.
-            aggregations = aggregation.remove_field(aggregations, ex.name);
-            buckets.unshift(from);
-            return fetcher();
+        .then(function(pointses) {
+            var points = fill_empties(_.flatten(pointses));
+            if (points.length > 0) {
+                last_emitted_timestamp = _.last(points).time;
+            }
+
+            return {
+                points: points,
+                eof: buckets.length === 0
+            };
         });
     }
 
@@ -342,6 +365,7 @@ function _time_filter(from, to, timeField) {
 function init(config) {
     DEFAULT_FETCH_SIZE = config.fetch_size || 10000;
     DEFAULT_DEEP_PAGING_LIMIT = config.deep_paging_limit || 200000;
+    DEFAULT_OPTIMIZED_REQUEST_CONCURRENCY = config.optimized_request_concurrency || 10;
 }
 
 module.exports = {

--- a/lib/read.js
+++ b/lib/read.js
@@ -44,6 +44,10 @@ var Read = Juttle.proc.source.extend({
         if (options.deep_paging_limit) {
             this.es_opts.deep_paging_limit = options.deep_paging_limit;
         }
+
+        if (options.optimized_request_concurrency) {
+            this.es_opts.optimized_request_concurrency = options.optimized_request_concurrency;
+        }
     },
 
     _default_config: function(property) {

--- a/test/optimization.spec.js
+++ b/test/optimization.spec.js
@@ -142,6 +142,17 @@ describe('optimization', function() {
                     return test_utils.check_optimization(start, end, type, '| reduce -every :s: count()');
                 });
 
+                it('optimizes reduce -every count() -optimized_request_concurrency 1', function() {
+                    return test_utils.check_optimization(start, end, type, '-optimized_request_concurrency 1 | reduce -every :s: count()');
+                });
+
+                it('optimizes reduce -every count() -optimized_request_concurrency 5', function() {
+                    return test_utils.check_optimization(start, end, type, '-optimized_request_concurrency 5 | reduce -every :s: count()');
+                });
+                it('optimizes reduce -every count() -optimized_request_concurrency 100', function() {
+                    return test_utils.check_optimization(start, end, type, '-optimized_request_concurrency 100 | reduce -every :s: count()');
+                });
+
                 it('optimizes reduce -every count() by', function() {
                     return test_utils.check_optimization(start, end, type, '| reduce -every :s: count() by clientip');
                 });


### PR DESCRIPTION
Run optimized requests to ES in parallel to minimize the effect of the round-trip latency. It's configurable with the `optimized_request_concurrency` parameter to read. Here are some numbers for AWS optimization tests:
```
        ✓ optimizes reduce -every count() -optimized_request_concurrency 1 (14976ms)
        ✓ optimizes reduce -every count() -optimized_request_concurrency 5 (3596ms)
        ✓ optimizes reduce -every count() -optimized_request_concurrency 100 (1093ms)
```
Nice! With extreme concurrency AWS is still 3x slower than local but that's better than the 50x of yore. I set the default at a moderate concurrency of 10 as I've been burned by `SearchPhaseExecutionException`s etc. too many times to want to set a huge default concurrency.

@demmer @VladVega 