### PR TITLE
Test node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
     - export CXX="g++-4.8"
 
 node_js:
+    - '4.2'
     - '5.0'
 
 services:

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
     "elasticsearch": "^10.0.1",
     "extendable-base": "^0.3.1",
     "request": "^2.44.0",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "uuid": "^2.0.1"
   },
   "peerDependencies": {
-      "juttle": "0.1.x"
+    "juttle": "^0.1.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/test/elastic-test-utils.js
+++ b/test/elastic-test-utils.js
@@ -30,16 +30,9 @@ var local_client = Promise.promisifyAll(new Elasticsearch.Client({
     host: 'localhost:9200'
 }));
 
-var aws_client = Promise.promisifyAll(new AmazonElasticsearchClient({
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-    service: 'es',
-    region: AWS_REGION,
-    host: AWS_HOST
-}));
-
 var test_index_prefix = 'my_index_prefix';
 var has_index_id = 'has_default_index';
+
 var config = [{
     id: LOCAL,
     address: 'localhost',
@@ -51,18 +44,30 @@ var config = [{
     port: 9999 // b's config is botched so we can get errors reading from it
 },
 {
-    id: AWS,
-    type: 'aws',
-    endpoint: AWS_HOST,
-    region: AWS_REGION
-},
-{
     id: has_index_id,
     address: 'localhost',
     port: 9200,
     index_prefix: test_index_prefix
 }
 ];
+
+var aws_client;
+if (_.contains(modes, AWS)) {
+    aws_client = Promise.promisifyAll(new AmazonElasticsearchClient({
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+        service: 'es',
+        region: AWS_REGION,
+        host: AWS_HOST
+    }));
+
+    config.push({
+        id: AWS,
+        type: 'aws',
+        endpoint: AWS_HOST,
+        region: AWS_REGION
+    });
+}
 
 var adapter = Elastic(config, Juttle);
 

--- a/test/elastic-test-utils.js
+++ b/test/elastic-test-utils.js
@@ -4,14 +4,18 @@ var expect = require('chai').expect;
 var _ = require('underscore');
 var Elasticsearch = require('elasticsearch');
 var AmazonElasticsearchClient = require('aws-es');
+var uuid = require('uuid');
+var util = require('util');
 
 var Juttle = require('juttle/lib/runtime').Juttle;
 var Elastic = require('../lib');
 var juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
+
 var check_juttle = juttle_test_utils.check_juttle;
 
 var AWS_HOST = 'search-dave-6jy2cskdfaye4ji6gfa6x375ve.us-west-2.es.amazonaws.com';
 var AWS_REGION = 'us-west-2';
+var TEST_RUN_ID = uuid.v4().substring(0, 8);
 
 var LOCAL = 'local';
 var AWS = 'aws';
@@ -73,8 +77,30 @@ var adapter = Elastic(config, Juttle);
 
 Juttle.adapters.register(adapter.name, adapter);
 
+function write(points, id) {
+    var program = 'emit -points %s | write elastic -id "%s" -index_prefix "%s"';
+    var write_program = util.format(program, JSON.stringify(points), id, TEST_RUN_ID);
+
+    return check_juttle({
+        program: write_program
+    });
+}
+
+function read(start, end, id, extra) {
+    var program = 'read elastic -from :%s: -to :%s: -id "%s" -index_prefix "%s" %s';
+    var read_program = util.format(program, start, end, id, TEST_RUN_ID, extra || '');
+
+    return check_juttle({
+        program: read_program
+    });
+}
+
+function read_all(type, extra) {
+    return read('10 years ago', 'now', type, extra);
+}
+
 function clear_data(type, indexes) {
-    indexes = indexes || 'logstash-*';
+    indexes = indexes || TEST_RUN_ID + '*';
     if (type === 'aws') {
         return aws_client.deleteAsync({index: indexes});
     } else {
@@ -82,11 +108,11 @@ function clear_data(type, indexes) {
     }
 }
 
-function verify_import(points, type) {
+function verify_import(points, type, indexes) {
     var client = type === 'aws' ? aws_client : local_client;
     return retry(function() {
         return client.searchAsync({
-            index: 'logstash-*',
+            index: indexes || TEST_RUN_ID + '*',
             type: '',
             body: {
                 size: 10000
@@ -126,15 +152,14 @@ function check_result_vs_expected_sorting_by(received, expected, field) {
 }
 
 // only works on linear flowgraphs
-function check_optimization(juttle, options) {
+function check_optimization(start, end, id, extra, options) {
     options = options || {};
-    var read_elastic_length = 'read elastic'.length;
-    var unoptimized_juttle = 'read elastic -optimize false ' + juttle.substring(read_elastic_length);
-    return Promise.map([juttle, unoptimized_juttle], function(program) {
-        return check_juttle({
-            program: program
-        });
-    })
+    extra = extra || '';
+    var unoptimized_extra = '-optimize false ' + extra;
+    return Promise.all([
+        read(start, end, id, extra),
+        read(start, end, id, unoptimized_extra)
+    ])
     .spread(function(optimized, unoptimized) {
         var opt_data = optimized.sinks.table;
         var unopt_data = unoptimized.sinks.table;
@@ -156,6 +181,9 @@ function list_indices() {
 }
 
 module.exports = {
+    read: read,
+    read_all: read_all,
+    write: write,
     modes: modes,
     check_result_vs_expected_sorting_by: check_result_vs_expected_sorting_by,
     verify_import: verify_import,
@@ -164,4 +192,5 @@ module.exports = {
     list_indices: list_indices,
     test_index_prefix: test_index_prefix,
     has_index_id: has_index_id,
+    test_id: TEST_RUN_ID,
 };


### PR DESCRIPTION
Back in https://github.com/juttle/juttle-elastic-adapter/pull/21 I lamentably had to get rid of testing on Node 4 because the parallel requests to my Amazon instance read/deleted each other's data. But now that we have https://github.com/juttle/juttle-elastic-adapter/pull/22 we can write to a unique set of indices per test run, so we don't have to worry about that. As a bonus it got a lot DRYer.

@demmer @VladVega 