### PR TITLE
Make aggregations work for Logstash

### DIFF
--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -33,7 +33,9 @@ function make_reducer_agg(target_field, reducer, arg, logstash) {
     var aggr = {};
     aggr[aggr_name] = { field: arg };
 
-    if (logstash) {
+    // in the logstash schema, you can only aggregate on .raw for string fields
+    // assume any cardinality/count aggregations are on string fields (XXX)
+    if (logstash && (aggr_name === 'cardinality' || aggr_name === 'value_count')) {
         aggr[aggr_name].field += '.raw';
     }
 
@@ -63,6 +65,7 @@ function make_bucket_agg(groupby, subagg, every, logstash) {
             terms: { field: groupby[0] }
         };
         if (logstash) {
+            // XXX assumes field is a string
             agg.terms.field += '.raw';
         }
     }
@@ -80,6 +83,7 @@ function make_bucket_agg(groupby, subagg, every, logstash) {
         };
 
         if (logstash) {
+            // XXX assumes all fields are strings
             agg.terms.params.fields = agg.terms.params.fields.map(function(field) {
                 return field + '.raw';
             });

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 
 var reducers = require('juttle/lib/runtime/reducers').reducers;
 var aggregation = require('./aggregation');
+var utils = require('./utils');
 
 var logger = require('juttle/lib/logger').getLogger('elastic-optimize');
 var ALLOWED_REDUCE_OPTIONS = ['every', 'forget', 'groupby', 'on'];
@@ -73,6 +74,11 @@ var optimizer = {
             logger.debug('optimization aborting -- cannot append reduce optimization to prior', optimization_info.type, 'optimization');
             return false;
         }
+
+        var indices = graph.node_get_option(read, 'index_prefix') ||
+            utils.default_prefix_for_id(graph.node_get_option(read, 'id'));
+        var logstash = !!indices.match(/logstash/);
+
         var groupby = graph.node_get_option(reduce, 'groupby');
         var grouped = groupby && groupby.length > 0;
         if (grouped && groupby.indexOf('time') !== -1) {
@@ -117,7 +123,7 @@ var optimizer = {
             }
 
             var arg = argument_object.value;
-            var aggr = aggregation.make_reducer_agg(target, reducer, arg);
+            var aggr = aggregation.make_reducer_agg(target, reducer, arg, logstash);
             if (aggr === null) {
                 logger.debug('optimization aborting -- unoptimizable reducer', JSON.stringify(reducer, null, 2));
                 return false;
@@ -129,7 +135,7 @@ var optimizer = {
         var empty_result = _.object(reduce.exprs.map(_empty_reducer_result));
 
         if (grouped) {
-            aggrs = aggregation.make_bucket_agg(groupby, aggrs);
+            aggrs = aggregation.make_bucket_agg(groupby, aggrs, null, logstash);
         }
 
         if (graph.node_has_option(reduce, 'every')) {

--- a/test/elastic-test-utils.js
+++ b/test/elastic-test-utils.js
@@ -77,26 +77,30 @@ var adapter = Elastic(config, Juttle);
 
 Juttle.adapters.register(adapter.name, adapter);
 
-function write(points, id) {
+function write(points, id, prefix) {
+    id = id || 'local';
+    prefix = prefix || TEST_RUN_ID;
     var program = 'emit -points %s | write elastic -id "%s" -index_prefix "%s"';
-    var write_program = util.format(program, JSON.stringify(points), id, TEST_RUN_ID);
+    var write_program = util.format(program, JSON.stringify(points), id, prefix);
 
     return check_juttle({
         program: write_program
     });
 }
 
-function read(start, end, id, extra) {
+function read(start, end, id, extra, prefix) {
+    id = id || 'local';
+    prefix = prefix || TEST_RUN_ID;
     var program = 'read elastic -from :%s: -to :%s: -id "%s" -index_prefix "%s" %s';
-    var read_program = util.format(program, start, end, id, TEST_RUN_ID, extra || '');
+    var read_program = util.format(program, start, end, id, prefix, extra || '');
 
     return check_juttle({
         program: read_program
     });
 }
 
-function read_all(type, extra) {
-    return read('10 years ago', 'now', type, extra);
+function read_all(type, extra, prefix) {
+    return read('10 years ago', 'now', type, extra, prefix);
 }
 
 function clear_data(type, indexes) {
@@ -180,6 +184,13 @@ function list_indices() {
         });
 }
 
+function put_template(name, template) {
+    return local_client.indices.putTemplate({
+        name: name,
+        body: template
+    });
+}
+
 module.exports = {
     read: read,
     read_all: read_all,
@@ -190,6 +201,7 @@ module.exports = {
     check_optimization: check_optimization,
     clear_data: clear_data,
     list_indices: list_indices,
+    put_template: put_template,
     test_index_prefix: test_index_prefix,
     has_index_id: has_index_id,
     test_id: TEST_RUN_ID,

--- a/test/logstash-optimization.spec.js
+++ b/test/logstash-optimization.spec.js
@@ -1,0 +1,71 @@
+var _ = require('underscore');
+var expect = require('chai').expect;
+
+var test_utils = require('./elastic-test-utils');
+var juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
+var check_juttle = juttle_test_utils.check_juttle;
+var points = require('./apache-sample');
+var expected_points = points.map(function(pt) {
+    var new_pt = _.clone(pt);
+    new_pt.time = new Date(new_pt.time).toISOString();
+    return new_pt;
+});
+
+// Register the adapter
+require('./elastic-test-utils');
+
+var logstash_template = require('./logstash-template');
+
+describe('logstash schema', function() {
+    this.timeout(300000);
+    before(function() {
+        return test_utils.put_template('logstash', logstash_template)
+            .then(function() {
+                var points_to_write = points.map(function(point) {
+                    var point_to_write = _.clone(point);
+                    point_to_write.time /= 1000;
+                    return point_to_write;
+                });
+
+                return test_utils.write(points_to_write, 'local', 'logstash-');
+            })
+            .then(function(res) {
+                expect(res.errors).deep.equal([]);
+                return test_utils.verify_import(points, 'local', 'logstash-*');
+            });
+    });
+
+    after(function() {
+        return test_utils.clear_data('local', 'logstash-*');
+    });
+
+    it('reduce by', function() {
+        return test_utils.read_all('local', '| reduce sum(bytes) by clientip', 'logstash-')
+            .then(function(result) {
+                var expected = [
+                    { clientip: '24.236.252.67', sum: 3638 },
+                    { clientip: '83.149.9.216', sum: 4379454 },
+                    { clientip: '93.114.45.13', sum: 86839 }
+                ];
+                var received = _.sortBy(result.sinks.table, 'clientip');
+                expect(result.errors).deep.equal([]);
+                expect(received).deep.equal(expected);
+            });
+    });
+
+    it('cardinality', function() {
+        return test_utils.read_all('local', '| reduce count_unique(clientip)', 'logstash-')
+            .then(function(result) {
+                expect(result.errors).deep.equal([]);
+                expect(result.sinks.table).deep.equal([{count_unique: 3}]);
+            });
+    });
+
+    it('value_count', function() {
+        return test_utils.read_all('local', '| reduce count(clientip)', 'logstash-')
+            .then(function(result) {
+                expect(result.errors).deep.equal([]);
+                expect(result.sinks.table).deep.equal([{count: 30}]);
+            });
+    });
+});

--- a/test/logstash-template.json
+++ b/test/logstash-template.json
@@ -1,0 +1,57 @@
+{
+    "template": "logstash*",
+    "mappings": {
+        "_default_": {
+            "dynamic_templates": [
+                {
+                    "message_field": {
+                        "mapping": {
+                            "index": "analyzed",
+                            "omit_norms": true,
+                            "type": "string"
+                        },
+                        "match": "message",
+                        "match_mapping_type": "string"
+                    }
+                },
+                {
+                    "string_fields": {
+                        "mapping": {
+                            "index": "analyzed",
+                            "omit_norms": true,
+                            "type": "string",
+                            "fielddata" : { "format" : "disabled" },
+                            "fields": {
+                                "raw": {
+                                    "ignore_above": 256,
+                                    "index": "not_analyzed",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "match": "*",
+                        "match_mapping_type": "string"
+                    }
+                }
+            ],
+            "_all": {
+                "enabled": true,
+                "omit_norms": true
+            },
+            "properties": {
+                "@version": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                },
+                "geoip": {
+                    "dynamic": "true",
+                    "properties": {
+                        "location": {
+                            "type": "geo_point"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Logstash puts the unanalyzed value for string fields in `.raw` , so to do aggregations on string fields we need to access the `.raw` property of the field instead of the field itself. Unfortunately, it doesn't do the same for numeric fields, so we have to access the field name itself to do aggregations on numeric fields. Until we design and implement some sort of schemas v5, the adapter will have no idea what fields are numbers and what are strings. 

So, to make the situation better in the short term, let's guess that any `group by`s are on string fields, any `min`, `max`, `sum`, or `avg`s are on numeric fields, and any `count_unique` or `count` with an argument are on string fields. If you `group by numeric_field`, `count_unique(numeric_field)`, or `count(numeric_field)`, we'll return some unexpected output as ES will use 0 for all values of `numeric_field` on all your documents. I don't see a way to work around this or even detect it, since the values could really all be 0. This seems like enough of an edge case that we can document and live with it to get `group by string_field` working for Logstash.

@demmer @VladVega @dmehra @rlgomes @go-oleg 