### PR TITLE
Support non-day index intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,23 +77,36 @@ Here's an example Juttle Elastic Adapter configuration that can read from either
 
 Then `read -id "amazon"` will return points stored in the Amazon Elasticsearch Service instance search-foo-bar.us-west-2.es.amazonaws.com (provided the access_key and secret_key are those of an account with authorization for it), and `read -id "local"` will return points stored in the Elasticsearch instance at localhost:9200.
 
+## Schema ##
+To read or write data, the adapter has to know the names of the indices storing that data in Elasticsearch. By default, the adapter assumes that it is dealing with data written by Logstash using Logstash's default configuration: that is, an index per day with name format `logstash-${yyyy.mm.dd}`.
+
+The schema used by the adapter is configurable via options to read, and you can modify the defaults in configuration. The prefix `logstash-` can be replaced by an arbitrary string with the `index_prefix` option, and the timespan of each index can be modified by the `index_interval` option. Valid values for `index_interval` are `"day"`, `"week"`, `"month"`, `"year"`, and `"none"`. With `"week"`, the adapter will use indices formatted `${prefix}${yyyy.ww}`, where `ww` ranges from 01 to 53 numbering the weeks in a year. With `"month"`, it will use `${prefix}${yyyy.mm}`, and with `"year"`, it will use `${prefix}${yyyy}`. With `"none"`, it will use just one index entirely specified by `index_prefix`.
+
+Also, the adapter expects all documents in Elasticsearch to have a field containing a timestamp. By default, it expects this to be the `@timestamp` field. This is configurable with the `-time_field` option to `read` and `write`.
+
 ## Usage
 
 ### Read options
 
 
-Name | Type | Required | Description
------|------|----------|-------------
-`from` | moment | no | select points after this time (inclusive)
-`to`   | moment | no | select points before this time (exclusive)
-`last` | duration | no | select points within this time in the past (exclusive)
-`id` | string | no | Read from the configured Elasticsearch endpoint with this ID
+Name | Type | Required | Description | Default
+-----|------|----------|-------------|---------
+`from` | moment | no | select points after this time (inclusive) | none, either `-from` and `-to` or `-last` must be specified
+`to`   | moment | no | select points before this time (exclusive) | none, either `-from` and `-to` or `-last` must be specified
+`last` | duration | no | select points within this time in the past (exclusive) | none, either `-from` and `-to` or `-last` must be specified
+`id` | string | no | read from the configured Elasticsearch endpoint with this ID | the first endpoint in `config.json`
+`index_prefix` | string | no | read from indices whose names start with this string | `logstash-`
+`index_interval` | string | no | read from indices that have this granularity. valid options: `"day"`, `"week"`, `"month"`, `"year"`, `"none"` | `day`
+`time_field` | string | no | field containing timestamps | `@timestamp`
 
 ### Write options
 
-Name | Type | Required | Description
------|------|----------|-------------
-`id` | string | no | Write to the configured Elasticsearch endpoint with this ID
+Name | Type | Required | Description | Default
+-----|------|----------|-------------|---------
+`id` | string | no | write to the configured Elasticsearch endpoint with this ID | the first endpoint in `config.json`
+`index_prefix` | string | no | write to indices whose names start with this string | `logstash-`
+`index_interval` | string | no | write to indices that have this granularity. valid options: `"day"` `"week"`, `"month"`, `"year"`, `"none"` | `day`
+`time_field` | string | no | field containing timestamps | `@timestamp`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/juttle/juttle-elastic-adapter.svg)](https://travis-ci.org/juttle/juttle-elastic-adapter)
 
-The Juttle Elastic Adapter enables reading and writing documents using [Elasticsearch](https://www.elastic.co/products/elasticsearch). It supports the [Logstash](https://www.elastic.co/products/logstash) schema, so it can read any documents stored in Elasticsearch by Logstash.
+The Juttle Elastic Adapter enables reading and writing documents using [Elasticsearch](https://www.elastic.co/products/elasticsearch).
 
 ## Examples
 
@@ -49,9 +49,9 @@ and `port` in this configuration.
 
 The value for `juttle-elastic-adapter` can also be an array of Elasticsearch host locations. Give each one a unique `id` field, and `read -id` and `write -id` will use the appropriate host.
 
-The Juttle Elastic Adapter can also make requests to Amazon Elasticsearch Service instances, which requires a little more configuration. To connect to Amazon Elasticsearch Service, an entry in the `juttle-elastic-adapter` config must have `{"type": "aws"}` as well as `"region"`, `"endpoint"`, `"access_key"`, and `"secret_key"` fields. `"access_key"` and `"secret_key"` can also be specified by the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` respectively.
+The Juttle Elastic Adapter can also make requests to Amazon Elasticsearch Service instances, which requires a little more configuration. To connect to Amazon Elasticsearch Service, an entry in the `juttle-elastic-adapter` config must have `{"type": "aws"}` as well as `region`, `endpoint`, `access_key`, and `secret_key` fields. `access_key` and `secret_key` can also be specified by the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` respectively.
 
-Here's an example Juttle Elastic Adapter configuration that can read from either a local Elasticsearch instance running on port 9200 or an Amazon Elasticsearch Service at `search-foo-bar.us-west-2.es.amazonaws.com`:
+Here's an example Juttle Elastic Adapter configuration that can connect to a local Elasticsearch instance running on port 9200 using `read/write elastic -id "local"` and an Amazon Elasticsearch Service at `search-foo-bar.us-west-2.es.amazonaws.com` using `read/write elastic -id "amazon"`:
 
 ```json
 {
@@ -75,14 +75,19 @@ Here's an example Juttle Elastic Adapter configuration that can read from either
 }
 ```
 
-Then `read -id "amazon"` will return points stored in the Amazon Elasticsearch Service instance search-foo-bar.us-west-2.es.amazonaws.com (provided the access_key and secret_key are those of an account with authorization for it), and `read -id "local"` will return points stored in the Elasticsearch instance at localhost:9200.
-
 ## Schema ##
-To read or write data, the adapter has to know the names of the indices storing that data in Elasticsearch. By default, the adapter assumes that it is dealing with data written by Logstash using Logstash's default configuration: that is, an index per day with name format `logstash-${yyyy.mm.dd}`.
+To read or write data, the adapter has to know the names of the indices storing that data in Elasticsearch. By default, the adapter writes points to an index called `juttle` and reads from all indices.
 
-The schema used by the adapter is configurable via options to read, and you can modify the defaults in configuration. The prefix `logstash-` can be replaced by an arbitrary string with the `index_prefix` option, and the timespan of each index can be modified by the `index_interval` option. Valid values for `index_interval` are `"day"`, `"week"`, `"month"`, `"year"`, and `"none"`. With `"week"`, the adapter will use indices formatted `${prefix}${yyyy.ww}`, where `ww` ranges from 01 to 53 numbering the weeks in a year. With `"month"`, it will use `${prefix}${yyyy.mm}`, and with `"year"`, it will use `${prefix}${yyyy}`. With `"none"`, it will use just one index entirely specified by `index_prefix`.
+You can choose indices to read and write from with the `-index` option, or you can specify an `index` for each configured Elasticsearch instance the adapter is connected to.
 
-Also, the adapter expects all documents in Elasticsearch to have a field containing a timestamp. By default, it expects this to be the `@timestamp` field. This is configurable with the `-time_field` option to `read` and `write`.
+For schemas such as [Logstash](https://www.elastic.co/products/logstash) that create indices at regular intervals, the adapter supports an `indexInterval` option. Valid values for `indexInterval` are `day`, `week`, `month`, `year`, and `none`. With `week`, the adapter will use indices formatted `${index}${yyyy.ww}`, where `ww` ranges from 01 to 53 numbering the weeks in a year. With `month`, it will use `${index}${yyyy.mm}`, and with `year`, it will use `${index}${yyyy}`. With `none`, the default, it will use just one index entirely specified by `index`. When using `indexInterval`, `index` should be the non-date portion of each index followed by `*`.
+
+Lastly, the adapter expects all documents in Elasticsearch to have a field containing a timestamp. By default, it expects this to be the `@timestamp` field. This is configurable with the `-timeField` option to `read` and `write`.
+
+#### Logstash ####
+Let's look at Logstash for an example of configuring a schema. Logstash creates daily indices that look like `logstash-2016.01.05`. By default, the adapter reads from all indices, so if you want to read from only Logstash's indices, use `logstash-*` for the `index` option.
+
+If you have many days' worth of data, Logstash will create many indices. Reading from many indices can be slow in Elasticsearch. To speed things up in this case, `read elastic` can narrow its search to only the days it needs for its query. To get this behavior, use `-indexInterval "day"`. Also, `write elastic` requires `-indexInterval "day"` for writing into daily indices.
 
 ## Usage
 
@@ -95,18 +100,18 @@ Name | Type | Required | Description | Default
 `to`   | moment | no | select points before this time (exclusive) | none, either `-from` and `-to` or `-last` must be specified
 `last` | duration | no | select points within this time in the past (exclusive) | none, either `-from` and `-to` or `-last` must be specified
 `id` | string | no | read from the configured Elasticsearch endpoint with this ID | the first endpoint in `config.json`
-`index_prefix` | string | no | read from indices whose names start with this string | `logstash-`
-`index_interval` | string | no | read from indices that have this granularity. valid options: `"day"`, `"week"`, `"month"`, `"year"`, `"none"` | `day`
-`time_field` | string | no | field containing timestamps | `@timestamp`
+`index` | string | no | index(es) to read from | `*`
+`indexInterval` | string | no | granularity of an index. valid options: `day`, `week`, `month`, `year`, `none` | `none`
+`timeField` | string | no | field containing timestamps | `@timestamp`
 
 ### Write options
 
 Name | Type | Required | Description | Default
 -----|------|----------|-------------|---------
 `id` | string | no | write to the configured Elasticsearch endpoint with this ID | the first endpoint in `config.json`
-`index_prefix` | string | no | write to indices whose names start with this string | `logstash-`
-`index_interval` | string | no | write to indices that have this granularity. valid options: `"day"` `"week"`, `"month"`, `"year"`, `"none"` | `day`
-`time_field` | string | no | field containing timestamps | `@timestamp`
+`index` | string | no | index to write to | `juttle`
+`indexInterval` | string | no | granularity of an index. valid options: `day` `week`, `month`, `year`, `none` | `none`
+`timeField` | string | no | field containing timestamps | `@timestamp`
 
 ## Contributing
 

--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -72,9 +72,9 @@ function _client_for_id(id) {
     }
 }
 
-function get_inserter(id, prefix) {
+function get_inserter(id, prefix, interval) {
     var client = _client_for_id(id);
-    return new Inserter(client, prefix);
+    return new Inserter(client, prefix, interval);
 }
 
 function fetcher(id, filter, query_start, query_end, options) {

--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -72,9 +72,9 @@ function _client_for_id(id) {
     }
 }
 
-function get_inserter(id, prefix, interval) {
+function get_inserter(id, index, interval) {
     var client = _client_for_id(id);
-    return new Inserter(client, prefix, interval);
+    return new Inserter(client, index, interval);
 }
 
 function fetcher(id, filter, query_start, query_end, options) {

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -37,10 +37,11 @@ function validate_event(event) {
     }
 }
 
-function EventsInserter(client, prefix) {
+function EventsInserter(client, prefix, interval) {
     this.client = client;
     this.events = [];
     this.prefix = prefix;
+    this.interval = interval;
 }
 
 EventsInserter.prototype.push = function(event) {
@@ -50,7 +51,7 @@ EventsInserter.prototype.push = function(event) {
 
     this.events.push({
         index: {
-            _index: utils.index_name(ts, this.prefix),
+            _index: utils.index_name(ts, this.prefix, this.interval),
             _type: 'event'
         }
     });

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -37,10 +37,10 @@ function validate_event(event) {
     }
 }
 
-function EventsInserter(client, prefix, interval) {
+function EventsInserter(client, index, interval) {
     this.client = client;
     this.events = [];
-    this.prefix = prefix;
+    this.index = index;
     this.interval = interval;
 }
 
@@ -51,7 +51,7 @@ EventsInserter.prototype.push = function(event) {
 
     this.events.push({
         index: {
-            _index: utils.index_name(ts, this.prefix, this.interval),
+            _index: utils.index_name(ts, this.index, this.interval),
             _type: 'event'
         }
     });

--- a/lib/query-common.js
+++ b/lib/query-common.js
@@ -85,10 +85,10 @@ function search(client, indices, body) {
     });
 }
 
-function get_indices(from, to, prefix, interval) {
+function get_indices(from, to, index, interval) {
     var times = getTimeIndices(from, to, interval);
     return times.map(function(time) {
-        return prefix + time;
+        return index + time;
     }).join(',');
 }
 

--- a/lib/query-common.js
+++ b/lib/query-common.js
@@ -1,5 +1,6 @@
 var Promise = require('bluebird');
 var _ = require('underscore');
+var utils = require('./utils');
 var request = Promise.promisifyAll(require('request'));
 request.async = Promise.promisify(request);
 
@@ -8,28 +9,42 @@ var errors = require('./es-errors');
 var utils = require('./utils');
 
 var SEARCH_SUFFIX = '/_search';
+// ES will blow up if you send it a URL of over 4096 characters
+// this determines the maximum length of a string of indices we'll
+// send, leaving some space for the rest of the URL
+var SAFE_INDICES_LENGTH = 3600;
 
-function getTimeIndices(from, to) {
-    var maxDays = JuttleMoment.duration(14, 'day');
+function getTimeIndices(from, to, interval) {
+    if (interval === 'none') { return ['']; }
 
     to = to || new JuttleMoment();
 
-    if (from === null || JuttleMoment.add(from, maxDays).lt(to)) {
+    if (from === null) {
         return ['*'];
     }
 
-    var day = JuttleMoment.duration(1, 'day');
+    var unit = JuttleMoment.duration(1, interval);
 
     var strings = [];
 
-    var current = from.quantize(JuttleMoment.duration(1, 'day'));
-    var max = to.quantize(JuttleMoment.duration(1, 'day'));
+    var current = from.quantize(unit);
+    var max = to.quantize(unit);
 
     while (current.lte(max)) {
-        // Push only the first part of the ISO string (e.g. 2014-01-01).
-        strings.push(current.valueOf().substr(0, 10).replace(/-/g, '.'));
+        var date = new Date(current.valueOf());
 
-        current = JuttleMoment.add(current, day);
+        strings.push(utils.index_date(date, interval));
+
+        current = JuttleMoment.add(current, unit);
+    }
+
+    var total_length = strings.reduce(function(memo, str) {
+        return memo + str.length;
+    }, 0);
+
+
+    if (total_length > SAFE_INDICES_LENGTH) {
+        return ['*'];
     }
 
     return strings;
@@ -38,6 +53,7 @@ function getTimeIndices(from, to) {
 function search(client, indices, body) {
     return client.searchAsync({
         index: indices,
+        ignoreUnavailable: true,
         type: '', // aws-es demands a type, this means all types
         body: body
     })
@@ -69,8 +85,8 @@ function search(client, indices, body) {
     });
 }
 
-function get_indices(from, to, prefix) {
-    var times = getTimeIndices(from, to);
+function get_indices(from, to, prefix, interval) {
+    var times = getTimeIndices(from, to, interval);
     return times.map(function(time) {
         return prefix + time;
     }).join(',');

--- a/lib/query.js
+++ b/lib/query.js
@@ -45,7 +45,7 @@ function fetcher(client, filter, query_start, query_end, options) {
     var fetch_size = options.fetch_size || DEFAULT_FETCH_SIZE;
     var deep_paging_limit = options.deep_paging_limit || DEFAULT_DEEP_PAGING_LIMIT;
 
-    var indices = common.get_indices(query_start, query_end, options.prefix);
+    var indices = common.get_indices(query_start, query_end, options.prefix, options.interval);
 
     function process_query_result(result, request_body) {
         var eof = false;
@@ -183,7 +183,7 @@ function fetcher(client, filter, query_start, query_end, options) {
 }
 
 function aggregation_fetcher(client, filter, query_start, query_end, options) {
-    var indices = common.get_indices(query_start, query_end, options.prefix);
+    var indices = common.get_indices(query_start, query_end, options.prefix, options.interval);
     var aggregations = options.aggregations;
     var reduce_every = aggregations.reduce_every;
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -37,6 +37,7 @@ function make_body(filter, from, to, direction, tm_filter, size) {
 }
 
 function fetcher(client, filter, query_start, query_end, options) {
+    var indices = options.indices;
     var bridge_offset = 0;
     var points_emitted_so_far = 0;
     var limit = options.limit;
@@ -44,8 +45,6 @@ function fetcher(client, filter, query_start, query_end, options) {
 
     var fetch_size = options.fetch_size || DEFAULT_FETCH_SIZE;
     var deep_paging_limit = options.deep_paging_limit || DEFAULT_DEEP_PAGING_LIMIT;
-
-    var indices = common.get_indices(query_start, query_end, options.prefix, options.interval);
 
     function process_query_result(result, request_body) {
         var eof = false;
@@ -183,7 +182,7 @@ function fetcher(client, filter, query_start, query_end, options) {
 }
 
 function aggregation_fetcher(client, filter, query_start, query_end, options) {
-    var indices = common.get_indices(query_start, query_end, options.prefix, options.interval);
+    var indices = options.indices;
     var aggregations = options.aggregations;
     var reduce_every = aggregations.reduce_every;
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -1,18 +1,19 @@
+var _ = require('underscore');
+
 var FilterESCompiler = require('./filter-es-compiler');
 var juttle_utils = require('juttle/lib/runtime').utils;
 var elastic = require('./elastic');
 var Juttle = require('juttle/lib/runtime').Juttle;
 var utils = require('./utils');
+var common = require('./query-common');
 
 var Read = Juttle.proc.source.extend({
     procName: 'elastic_read',
 
     initialize: function(options, params) {
         this.id = options.id;
-        this.prefix = options.index_prefix || utils.default_prefix_for_id(this.id);
-        this.interval = options.index_interval || utils.default_interval_for_id(this.id);
-        utils.ensure_valid_interval(this.interval);
         this._setup_time_filter(options);
+        this._setup_index(options);
         var filter_ast = params.filter_ast;
         if (filter_ast) {
             var filter_es_compiler = new FilterESCompiler();
@@ -23,7 +24,7 @@ var Read = Juttle.proc.source.extend({
         var optimization_info = params && params.optimization_info || {};
 
         this.es_opts = {
-            prefix: this.prefix,
+            indices: this.index,
             interval: this.interval,
             limit: optimization_info.limit,
             aggregations: optimization_info.aggregations
@@ -35,6 +36,20 @@ var Read = Juttle.proc.source.extend({
 
         if (options.deep_paging_limit) {
             this.es_opts.deep_paging_limit = options.deep_paging_limit;
+        }
+    },
+
+    _setup_index: function(options) {
+        this.index = options.index || utils.default_read_index_for_id(this.id);
+        this.interval = options.indexInterval || utils.default_interval_for_id(this.id);
+        utils.ensure_valid_interval(this.interval);
+        if (this.interval !== 'none') {
+            if (_.last(this.index) !== '*') {
+                throw new Error('with indexInterval, index must end in *');
+            }
+
+            var prefix = this.index.substring(0, this.index.length - 1);
+            this.index = common.get_indices(this.from, this.to, prefix, this.interval);
         }
     },
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -10,6 +10,8 @@ var Read = Juttle.proc.source.extend({
     initialize: function(options, params) {
         this.id = options.id;
         this.prefix = options.index_prefix || utils.default_prefix_for_id(this.id);
+        this.interval = options.index_interval || utils.default_interval_for_id(this.id);
+        utils.ensure_valid_interval(this.interval);
         this._setup_time_filter(options);
         var filter_ast = params.filter_ast;
         if (filter_ast) {
@@ -22,6 +24,7 @@ var Read = Juttle.proc.source.extend({
 
         this.es_opts = {
             prefix: this.prefix,
+            interval: this.interval,
             limit: optimization_info.limit,
             aggregations: optimization_info.aggregations
         };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,11 @@
 var _ = require('underscore');
 var current_week_number = require('current-week-number');
 
-var DEFAULT_PREFIXES, DEFAULT_INTERVALS;
-var DEFAULT_DEFAULT_PREFIX = 'logstash-';
-var DEFAULT_DEFAULT_INTERVAL = 'day';
+var DEFAULT_INDEXES = {};
+var DEFAULT_INTERVALS = {};
+var DEFAULT_DEFAULT_READ_INDEX = '*';
+var DEFAULT_DEFAULT_WRITE_INDEX = 'juttle';
+var DEFAULT_DEFAULT_INTERVAL = 'none';
 
 function pointsFromESDocs(hits) {
     return hits.map(function(hit) {
@@ -16,8 +18,8 @@ function pointsFromESDocs(hits) {
     });
 }
 
-function index_name(timestamp, prefix, interval) {
-    return prefix + index_date(timestamp, interval);
+function index_name(timestamp, index, interval) {
+    return index + index_date(timestamp, interval);
 }
 
 // YYYY.MM.dd
@@ -53,35 +55,31 @@ function index_date(timestamp, interval) {
 }
 
 function init(config) {
-    DEFAULT_PREFIXES = {};
-    DEFAULT_INTERVALS = {};
     config.forEach(function(entry) {
         if (entry.hasOwnProperty('id')) {
-            if (entry.hasOwnProperty('index_prefix')) {
-                DEFAULT_PREFIXES[entry.id] = entry.index_prefix;
+            if (entry.hasOwnProperty('index')) {
+                DEFAULT_INDEXES[entry.id] = entry.index;
             }
 
-            if (entry.hasOwnProperty('index_interval')) {
-                DEFAULT_INTERVALS[entry.id] = entry.index_interval;
+            if (entry.hasOwnProperty('indexInterval')) {
+                DEFAULT_INTERVALS[entry.id] = entry.indexInterval;
             }
         }
     });
 }
 
-function default_prefix_for_id(id) {
-    if (DEFAULT_PREFIXES.hasOwnProperty(id)) {
-        return DEFAULT_PREFIXES[id];
-    }
+var default_read_index_for_id = _default_for_id(DEFAULT_INDEXES, DEFAULT_DEFAULT_READ_INDEX);
+var default_write_index_for_id = _default_for_id(DEFAULT_INDEXES, DEFAULT_DEFAULT_WRITE_INDEX);
+var default_interval_for_id = _default_for_id(DEFAULT_INTERVALS, DEFAULT_DEFAULT_INTERVAL);
 
-    return DEFAULT_DEFAULT_PREFIX;
-}
+function _default_for_id(defaults_object, default_default) {
+    return function(id) {
+        if (defaults_object.hasOwnProperty(id)) {
+            return defaults_object[id];
+        }
 
-function default_interval_for_id(id) {
-    if (DEFAULT_INTERVALS.hasOwnProperty(id)) {
-        return DEFAULT_INTERVALS[id];
-    }
-
-    return DEFAULT_DEFAULT_INTERVAL;
+        return default_default;
+    };
 }
 
 function ensure_valid_interval(interval) {
@@ -96,7 +94,8 @@ module.exports = {
     index_name: index_name,
     index_date: index_date,
     pointsFromESDocs: pointsFromESDocs,
-    default_prefix_for_id: default_prefix_for_id,
+    default_read_index_for_id: default_read_index_for_id,
+    default_write_index_for_id: default_write_index_for_id,
     default_interval_for_id: default_interval_for_id,
     ensure_valid_interval: ensure_valid_interval,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,9 @@
 var _ = require('underscore');
+var current_week_number = require('current-week-number');
 
-var DEFAULT_PREFIXES;
+var DEFAULT_PREFIXES, DEFAULT_INTERVALS;
 var DEFAULT_DEFAULT_PREFIX = 'logstash-';
+var DEFAULT_DEFAULT_INTERVAL = 'day';
 
 function pointsFromESDocs(hits) {
     return hits.map(function(hit) {
@@ -14,28 +16,54 @@ function pointsFromESDocs(hits) {
     });
 }
 
-function index_name(timestamp, prefix) {
-    return prefix + index_date(timestamp);
+function index_name(timestamp, prefix, interval) {
+    return prefix + index_date(timestamp, interval);
 }
 
 // YYYY.MM.dd
-function index_date(timestamp) {
-    var year = timestamp.getUTCFullYear();
-    var month = (timestamp.getUTCMonth() + 1).toString();
-    var day = timestamp.getUTCDate().toString();
-
+function index_date(timestamp, interval) {
     function double_digitize(str) {
         return (str.length === 1) ? ('0' + str) : str;
     }
 
-    return [year, double_digitize(month), double_digitize(day)].join('.');
+    var year = timestamp.getUTCFullYear();
+    var month = (timestamp.getUTCMonth() + 1).toString();
+
+    switch (interval) {
+        case 'day':
+            var day = timestamp.getUTCDate().toString();
+            return [year, double_digitize(month), double_digitize(day)].join('.');
+
+        case 'week':
+            var week = current_week_number(timestamp);
+            return [year, double_digitize(week)].join('.');
+
+        case 'month':
+            return [year, double_digitize(month)].join('.');
+
+        case 'year':
+            return year;
+
+        case 'none':
+            return '';
+
+        default:
+            throw new Error('invalid interval: ' + interval + '; accepted intervals are "day", "week", "month" "year", and "none"');
+    }
 }
 
 function init(config) {
     DEFAULT_PREFIXES = {};
+    DEFAULT_INTERVALS = {};
     config.forEach(function(entry) {
-        if (entry.hasOwnProperty('id') && entry.hasOwnProperty('index_prefix')) {
-            DEFAULT_PREFIXES[entry.id] = entry.index_prefix;
+        if (entry.hasOwnProperty('id')) {
+            if (entry.hasOwnProperty('index_prefix')) {
+                DEFAULT_PREFIXES[entry.id] = entry.index_prefix;
+            }
+
+            if (entry.hasOwnProperty('index_interval')) {
+                DEFAULT_INTERVALS[entry.id] = entry.index_interval;
+            }
         }
     });
 }
@@ -48,9 +76,27 @@ function default_prefix_for_id(id) {
     return DEFAULT_DEFAULT_PREFIX;
 }
 
+function default_interval_for_id(id) {
+    if (DEFAULT_INTERVALS.hasOwnProperty(id)) {
+        return DEFAULT_INTERVALS[id];
+    }
+
+    return DEFAULT_DEFAULT_INTERVAL;
+}
+
+function ensure_valid_interval(interval) {
+    var valid_intervals = ['day', 'week', 'month', 'year', 'none'];
+    if (!_.contains(valid_intervals, interval)) {
+        throw new Error('invalid interval: ' + interval + '; accepted intervals are "day", "week", "month" "year", and "none"');
+    }
+}
+
 module.exports = {
     init: init,
     index_name: index_name,
+    index_date: index_date,
     pointsFromESDocs: pointsFromESDocs,
     default_prefix_for_id: default_prefix_for_id,
+    default_interval_for_id: default_interval_for_id,
+    ensure_valid_interval: ensure_valid_interval,
 };

--- a/lib/write.js
+++ b/lib/write.js
@@ -9,13 +9,11 @@ var Write = Juttle.proc.sink.extend({
         this.eofs = 0;
         this.id = options.id;
         this.in_progress_writes = 0;
-        this.prefix = options.index_prefix || utils.default_prefix_for_id(this.id);
-        this.interval = options.index_interval || utils.default_interval_for_id(this.id);
-        utils.ensure_valid_interval(this.interval);
+        this._setup_index(options);
     },
     process: function(points) {
         var self = this;
-        var inserter = elastic.get_inserter(this.id, this.prefix, this.interval);
+        var inserter = elastic.get_inserter(this.id, this.index, this.interval);
         for (var i = 0; i < points.length; i++) {
             try {
                 inserter.push(points[i]);
@@ -34,6 +32,31 @@ var Write = Juttle.proc.sink.extend({
             self._maybe_done();
         });
     },
+
+    _setup_index: function(options) {
+        var index = options.index || utils.default_write_index_for_id(this.id);
+        this.interval = options.indexInterval || utils.default_interval_for_id(this.id);
+        utils.ensure_valid_interval(this.interval);
+
+        var star_index = index.indexOf('*');
+        if (star_index !== -1 && star_index !== index.length - 1) {
+            throw new Error('cannot write to index pattern: ' + index);
+        }
+
+        if (this.interval !== 'none') {
+            if (star_index !== index.length - 1) {
+                throw new Error('with indexInterval, index must end in *');
+            }
+
+            // drop the star, insert.js wants only the prefix
+            index = index.substring(0, index.length - 1);
+        } else if (star_index !== -1) {
+            throw new Error('index for write with interval "none" cannot contain *');
+        }
+
+        this.index = index;
+    },
+
     _maybe_done: function() {
         if (this.eofs === this.ins.length && this.in_progress_writes === 0) {
             this.emit_eof();

--- a/lib/write.js
+++ b/lib/write.js
@@ -10,10 +10,12 @@ var Write = Juttle.proc.sink.extend({
         this.id = options.id;
         this.in_progress_writes = 0;
         this.prefix = options.index_prefix || utils.default_prefix_for_id(this.id);
+        this.interval = options.index_interval || utils.default_interval_for_id(this.id);
+        utils.ensure_valid_interval(this.interval);
     },
     process: function(points) {
         var self = this;
-        var inserter = elastic.get_inserter(this.id, this.prefix);
+        var inserter = elastic.get_inserter(this.id, this.prefix, this.interval);
         for (var i = 0; i < points.length; i++) {
             try {
                 inserter.push(points[i]);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "aws-es": "juttle/aws-es.git",
     "bluebird": "^2.9.30",
     "bluebird-retry": "^0.5.2",
+    "current-week-number": "^1.0.7",
     "elasticsearch": "^10.0.1",
     "extendable-base": "^0.3.1",
     "request": "^2.44.0",

--- a/test/elastic-adapter.spec.js
+++ b/test/elastic-adapter.spec.js
@@ -162,13 +162,7 @@ describe('elastic source', function() {
         });
 
         it('errors if you read from nonexistent id', function() {
-            return test_utils.read_all('bananas')
-            .then(function() {
-                throw new Error('should have failed');
-            })
-            .catch(function(err) {
-                expect(err.message).equal('invalid id: bananas');
-            });
+            return test_utils.expect_to_fail(test_utils.read_all('bananas'), 'invalid id: bananas');
         });
 
         it('errors if you write to nonexistent id', function() {

--- a/test/elastic-test-utils.js
+++ b/test/elastic-test-utils.js
@@ -34,7 +34,7 @@ var local_client = Promise.promisifyAll(new Elasticsearch.Client({
     host: 'localhost:9200'
 }));
 
-var test_index_prefix = 'my_index_prefix';
+var test_index = 'my_index';
 var has_index_id = 'has_default_index';
 
 var config = [{
@@ -51,7 +51,7 @@ var config = [{
     id: has_index_id,
     address: 'localhost',
     port: 9200,
-    index_prefix: test_index_prefix
+    index: test_index
 }
 ];
 
@@ -77,28 +77,30 @@ var adapter = Elastic(config, Juttle);
 
 Juttle.adapters.register(adapter.name, adapter);
 
-function write(points, id, interval) {
-    interval = interval || 'day';
-    var program = 'emit -points %s | write elastic -id "%s" -index_prefix "%s" -index_interval "%s"';
-    var write_program = util.format(program, JSON.stringify(points), id, TEST_RUN_ID, interval);
+function write(points, id, index, interval) {
+    interval = interval || 'none';
+    index = index || TEST_RUN_ID;
+    var program = 'emit -points %s | write elastic -id "%s" -index "%s" -indexInterval "%s"';
+    var write_program = util.format(program, JSON.stringify(points), id, index, interval);
 
     return check_juttle({
         program: write_program
     });
 }
 
-function read(start, end, id, extra, interval) {
-    interval = interval || 'day';
-    var program = 'read elastic -from :%s: -to :%s: -id "%s" -index_prefix "%s" -index_interval "%s" %s';
-    var read_program = util.format(program, start, end, id, TEST_RUN_ID, interval, extra || '');
+function read(start, end, id, extra, index, interval) {
+    interval = interval || 'none';
+    index = index || TEST_RUN_ID;
+    var program = 'read elastic -from :%s: -to :%s: -id "%s" -index "%s" -indexInterval "%s" %s';
+    var read_program = util.format(program, start, end, id, index, interval, extra || '');
 
     return check_juttle({
         program: read_program
     });
 }
 
-function read_all(type, extra, interval) {
-    return read('10 years ago', 'now', type, extra, interval);
+function read_all(type, extra, index, interval) {
+    return read('10 years ago', 'now', type, extra, index, interval);
 }
 
 function clear_data(type, indexes) {
@@ -112,14 +114,16 @@ function clear_data(type, indexes) {
 
 function verify_import(points, type, indexes) {
     var client = type === 'aws' ? aws_client : local_client;
+    var request_body = {
+        index: indexes || TEST_RUN_ID + '*',
+        type: '',
+        body: {
+            size: 10000
+        }
+    };
+
     return retry(function() {
-        return client.searchAsync({
-            index: indexes || TEST_RUN_ID + '*',
-            type: '',
-            body: {
-                size: 10000
-            }
-        })
+        return client.searchAsync(request_body)
         .then(function(body) {
             if (Array.isArray(body)) {
                 body = body[0];
@@ -199,7 +203,7 @@ module.exports = {
     check_optimization: check_optimization,
     clear_data: clear_data,
     list_indices: list_indices,
-    test_index_prefix: test_index_prefix,
+    test_index: test_index,
     has_index_id: has_index_id,
     test_id: TEST_RUN_ID,
     expect_to_fail: expect_to_fail,

--- a/test/index-intervals.spec.js
+++ b/test/index-intervals.spec.js
@@ -1,0 +1,80 @@
+var _ = require('underscore');
+var Promise = require('bluebird');
+var request = Promise.promisifyAll(require('request'));
+request.async = Promise.promisify(request);
+var retry = require('bluebird-retry');
+var expect = require('chai').expect;
+var util = require('util');
+
+var test_utils = require('./elastic-test-utils');
+var juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
+var check_juttle = juttle_test_utils.check_juttle;
+var points = require('./apache-sample');
+var expected_points = points.map(function(pt) {
+    var new_pt = _.clone(pt);
+    new_pt.time = new Date(new_pt.time).toISOString();
+    return new_pt;
+});
+
+// Register the adapter
+require('./elastic-test-utils');
+
+describe('index intervals', function() {
+    this.timeout(300000);
+    var points_to_write = points.map(function(point) {
+        var point_to_write = _.clone(point);
+        point_to_write.time /= 1000;
+        return point_to_write;
+    });
+
+    afterEach(function() {
+        return test_utils.clear_data();
+    });
+
+    function check(interval, suffix) {
+        return test_utils.write(points_to_write, 'local', interval)
+            .then(function() {
+                return test_utils.verify_import(expected_points);
+            })
+            .then(function() {
+                return test_utils.list_indices();
+            })
+            .then(function(indices) {
+                var week_indices = indices.filter(function(index) {
+                    return index.substring(index.length - suffix.length) === suffix;
+                });
+
+                expect(week_indices.length).at.least(1);
+                var start = '2014-09-17T14:13:42.000Z';
+                var end = '2014-10-17T14:13:42.000Z';
+                return test_utils.read(start, end, 'local', '', interval);
+            })
+            .then(function(result) {
+                test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected_points, 'bytes');
+            });
+    }
+
+    it('writes and reads with weekly indexes', function() {
+        return check('week', '2014.38');
+    });
+
+    it('writes and reads with monthly indexes', function() {
+        return check('month', '2014.09');
+    });
+
+    it('writes and reads with yearly indexes', function() {
+        return check('year', '2014');
+    });
+
+    it('writes and reads with one index', function() {
+        return check('none', '');
+    });
+
+    it('errors on bogus interval', function() {
+        var message = 'invalid interval: bananas; accepted intervals are "day", "week", "month" "year", and "none"';
+        return Promise.all([
+            test_utils.expect_to_fail(test_utils.read_all('local', '', 'bananas'), message),
+            test_utils.expect_to_fail(test_utils.write(points_to_write, 'local', 'bananas'), message)
+        ]);
+    });
+});


### PR DESCRIPTION
resolves #25 

Now you can read and write from weekly, monthly, yearly,
or singular indices by specifying -index_interval in
read commands or configuration.

@demmer @VladVega @go-oleg @rlgomes @dmehra 