### PR TITLE
Support non-day index intervals

### DIFF
--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -72,9 +72,9 @@ function _client_for_id(id) {
     }
 }
 
-function get_inserter(id, prefix) {
+function get_inserter(id, prefix, interval) {
     var client = _client_for_id(id);
-    return new Inserter(client, prefix);
+    return new Inserter(client, prefix, interval);
 }
 
 function fetcher(id, filter, query_start, query_end, options) {

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -37,10 +37,11 @@ function validate_event(event) {
     }
 }
 
-function EventsInserter(client, prefix) {
+function EventsInserter(client, prefix, interval) {
     this.client = client;
     this.events = [];
     this.prefix = prefix;
+    this.interval = interval;
 }
 
 EventsInserter.prototype.push = function(event) {
@@ -50,7 +51,7 @@ EventsInserter.prototype.push = function(event) {
 
     this.events.push({
         index: {
-            _index: utils.index_name(ts, this.prefix),
+            _index: utils.index_name(ts, this.prefix, this.interval),
             _type: 'event'
         }
     });

--- a/lib/query-common.js
+++ b/lib/query-common.js
@@ -1,5 +1,6 @@
 var Promise = require('bluebird');
 var _ = require('underscore');
+var utils = require('./utils');
 var request = Promise.promisifyAll(require('request'));
 request.async = Promise.promisify(request);
 
@@ -8,28 +9,42 @@ var errors = require('./es-errors');
 var utils = require('./utils');
 
 var SEARCH_SUFFIX = '/_search';
+// ES will blow up if you send it a URL of over 4096 characters
+// this determines the maximum length of a string of indices we'll
+// send, leaving some space for the rest of the URL
+var SAFE_INDICES_LENGTH = 3600;
 
-function getTimeIndices(from, to) {
-    var maxDays = JuttleMoment.duration(14, 'day');
+function getTimeIndices(from, to, interval) {
+    if (interval === 'none') { return ['']; }
 
     to = to || new JuttleMoment();
 
-    if (from === null || JuttleMoment.add(from, maxDays).lt(to)) {
+    if (from === null) {
         return ['*'];
     }
 
-    var day = JuttleMoment.duration(1, 'day');
+    var unit = JuttleMoment.duration(1, interval);
 
     var strings = [];
 
-    var current = from.quantize(JuttleMoment.duration(1, 'day'));
-    var max = to.quantize(JuttleMoment.duration(1, 'day'));
+    var current = from.quantize(unit);
+    var max = to.quantize(unit);
 
     while (current.lte(max)) {
-        // Push only the first part of the ISO string (e.g. 2014-01-01).
-        strings.push(current.valueOf().substr(0, 10).replace(/-/g, '.'));
+        var date = new Date(current.valueOf());
 
-        current = JuttleMoment.add(current, day);
+        strings.push(utils.index_date(date, interval));
+
+        current = JuttleMoment.add(current, unit);
+    }
+
+    var total_length = strings.reduce(function(memo, str) {
+        return memo + str.length;
+    }, 0);
+
+
+    if (total_length > SAFE_INDICES_LENGTH) {
+        return ['*'];
     }
 
     return strings;
@@ -38,6 +53,7 @@ function getTimeIndices(from, to) {
 function search(client, indices, body) {
     return client.searchAsync({
         index: indices,
+        ignoreUnavailable: true,
         type: '', // aws-es demands a type, this means all types
         body: body
     })
@@ -69,8 +85,8 @@ function search(client, indices, body) {
     });
 }
 
-function get_indices(from, to, prefix) {
-    var times = getTimeIndices(from, to);
+function get_indices(from, to, prefix, interval) {
+    var times = getTimeIndices(from, to, interval);
     return times.map(function(time) {
         return prefix + time;
     }).join(',');

--- a/lib/query.js
+++ b/lib/query.js
@@ -45,7 +45,7 @@ function fetcher(client, filter, query_start, query_end, options) {
     var fetch_size = options.fetch_size || DEFAULT_FETCH_SIZE;
     var deep_paging_limit = options.deep_paging_limit || DEFAULT_DEEP_PAGING_LIMIT;
 
-    var indices = common.get_indices(query_start, query_end, options.prefix);
+    var indices = common.get_indices(query_start, query_end, options.prefix, options.interval);
 
     function process_query_result(result, request_body) {
         var eof = false;
@@ -183,7 +183,7 @@ function fetcher(client, filter, query_start, query_end, options) {
 }
 
 function aggregation_fetcher(client, filter, query_start, query_end, options) {
-    var indices = common.get_indices(query_start, query_end, options.prefix);
+    var indices = common.get_indices(query_start, query_end, options.prefix, options.interval);
     var aggregations = options.aggregations;
     var reduce_every = aggregations.reduce_every;
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -11,6 +11,8 @@ var Read = Juttle.proc.source.extend({
     initialize: function(options, params) {
         this.id = options.id;
         this.prefix = options.index_prefix || utils.default_prefix_for_id(this.id);
+        this.interval = options.index_interval || utils.default_interval_for_id(this.id);
+        utils.ensure_valid_interval(this.interval);
         this._setup_time_filter(options);
         var filter_ast = params.filter_ast;
         if (filter_ast) {
@@ -23,6 +25,7 @@ var Read = Juttle.proc.source.extend({
 
         this.es_opts = {
             prefix: this.prefix,
+            interval: this.interval,
             limit: optimization_info.limit,
             aggregations: optimization_info.aggregations
         };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,9 @@
 var _ = require('underscore');
+var current_week_number = require('current-week-number');
 
-var DEFAULT_PREFIXES;
+var DEFAULT_PREFIXES, DEFAULT_INTERVALS;
 var DEFAULT_DEFAULT_PREFIX = 'logstash-';
+var DEFAULT_DEFAULT_INTERVAL = 'day';
 
 function pointsFromESDocs(hits) {
     return hits.map(function(hit) {
@@ -14,28 +16,54 @@ function pointsFromESDocs(hits) {
     });
 }
 
-function index_name(timestamp, prefix) {
-    return prefix + index_date(timestamp);
+function index_name(timestamp, prefix, interval) {
+    return prefix + index_date(timestamp, interval);
 }
 
 // YYYY.MM.dd
-function index_date(timestamp) {
-    var year = timestamp.getUTCFullYear();
-    var month = (timestamp.getUTCMonth() + 1).toString();
-    var day = timestamp.getUTCDate().toString();
-
+function index_date(timestamp, interval) {
     function double_digitize(str) {
         return (str.length === 1) ? ('0' + str) : str;
     }
 
-    return [year, double_digitize(month), double_digitize(day)].join('.');
+    var year = timestamp.getUTCFullYear();
+    var month = (timestamp.getUTCMonth() + 1).toString();
+
+    switch (interval) {
+        case 'day':
+            var day = timestamp.getUTCDate().toString();
+            return [year, double_digitize(month), double_digitize(day)].join('.');
+
+        case 'week':
+            var week = current_week_number(timestamp);
+            return [year, double_digitize(week)].join('.');
+
+        case 'month':
+            return [year, double_digitize(month)].join('.');
+
+        case 'year':
+            return year;
+
+        case 'none':
+            return '';
+
+        default:
+            throw new Error('invalid interval: ' + interval + '; accepted intervals are "day", "week", "month" "year", and "none"');
+    }
 }
 
 function init(config) {
     DEFAULT_PREFIXES = {};
+    DEFAULT_INTERVALS = {};
     config.forEach(function(entry) {
-        if (entry.hasOwnProperty('id') && entry.hasOwnProperty('index_prefix')) {
-            DEFAULT_PREFIXES[entry.id] = entry.index_prefix;
+        if (entry.hasOwnProperty('id')) {
+            if (entry.hasOwnProperty('index_prefix')) {
+                DEFAULT_PREFIXES[entry.id] = entry.index_prefix;
+            }
+
+            if (entry.hasOwnProperty('index_interval')) {
+                DEFAULT_INTERVALS[entry.id] = entry.index_interval;
+            }
         }
     });
 }
@@ -48,9 +76,27 @@ function default_prefix_for_id(id) {
     return DEFAULT_DEFAULT_PREFIX;
 }
 
+function default_interval_for_id(id) {
+    if (DEFAULT_INTERVALS.hasOwnProperty(id)) {
+        return DEFAULT_INTERVALS[id];
+    }
+
+    return DEFAULT_DEFAULT_INTERVAL;
+}
+
+function ensure_valid_interval(interval) {
+    var valid_intervals = ['day', 'week', 'month', 'year', 'none'];
+    if (!_.contains(valid_intervals, interval)) {
+        throw new Error('invalid interval: ' + interval + '; accepted intervals are "day", "week", "month" "year", and "none"');
+    }
+}
+
 module.exports = {
     init: init,
     index_name: index_name,
+    index_date: index_date,
     pointsFromESDocs: pointsFromESDocs,
     default_prefix_for_id: default_prefix_for_id,
+    default_interval_for_id: default_interval_for_id,
+    ensure_valid_interval: ensure_valid_interval,
 };

--- a/lib/write.js
+++ b/lib/write.js
@@ -10,10 +10,12 @@ var Write = Juttle.proc.sink.extend({
         this.id = options.id;
         this.in_progress_writes = 0;
         this.prefix = options.index_prefix || utils.default_prefix_for_id(this.id);
+        this.interval = options.index_interval || utils.default_interval_for_id(this.id);
+        utils.ensure_valid_interval(this.interval);
     },
     process: function(points) {
         var self = this;
-        var inserter = elastic.get_inserter(this.id, this.prefix);
+        var inserter = elastic.get_inserter(this.id, this.prefix, this.interval);
         for (var i = 0; i < points.length; i++) {
             try {
                 inserter.push(points[i]);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "juttle-elastic-adapter",
   "version": "0.1.0",
   "description": "Juttle adapter for Elasticsearch",
-  "keywords": ["juttle", "adapter", "elasticsearch"],
+  "keywords": [
+    "juttle",
+    "adapter",
+    "elasticsearch"
+  ],
   "homepage": "https://github.com/juttle/juttle-elastic-adapter",
   "bugs": "https://github.com/juttle/juttle-elastic-adapter/issues",
   "license": "Apache-2.0",
@@ -19,6 +23,7 @@
     "bluebird": "^2.9.30",
     "bluebird-retry": "^0.5.2",
     "chai": "^3.4.1",
+    "current-week-number": "^1.0.7",
     "elasticsearch": "^10.0.1",
     "extendable-base": "^0.3.1",
     "request": "^2.44.0",

--- a/test/elastic-adapter.spec.js
+++ b/test/elastic-adapter.spec.js
@@ -146,13 +146,7 @@ describe('elastic source', function() {
         });
 
         it('errors if you read from nonexistent id', function() {
-            return test_utils.read_all('bananas')
-            .then(function() {
-                throw new Error('should have failed');
-            })
-            .catch(function(err) {
-                expect(err.message).equal('invalid id: bananas');
-            });
+            return test_utils.expect_to_fail(test_utils.read_all('bananas'), 'invalid id: bananas');
         });
 
         it('errors if you write to nonexistent id', function() {

--- a/test/index-intervals.spec.js
+++ b/test/index-intervals.spec.js
@@ -1,0 +1,80 @@
+var _ = require('underscore');
+var Promise = require('bluebird');
+var request = Promise.promisifyAll(require('request'));
+request.async = Promise.promisify(request);
+var retry = require('bluebird-retry');
+var expect = require('chai').expect;
+var util = require('util');
+
+var test_utils = require('./elastic-test-utils');
+var juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
+var check_juttle = juttle_test_utils.check_juttle;
+var points = require('./apache-sample');
+var expected_points = points.map(function(pt) {
+    var new_pt = _.clone(pt);
+    new_pt.time = new Date(new_pt.time).toISOString();
+    return new_pt;
+});
+
+// Register the adapter
+require('./elastic-test-utils');
+
+describe('index intervals', function() {
+    this.timeout(300000);
+    var points_to_write = points.map(function(point) {
+        var point_to_write = _.clone(point);
+        point_to_write.time /= 1000;
+        return point_to_write;
+    });
+
+    afterEach(function() {
+        return test_utils.clear_data();
+    });
+
+    function check(interval, suffix) {
+        return test_utils.write(points_to_write, 'local', interval)
+            .then(function() {
+                return test_utils.verify_import(expected_points);
+            })
+            .then(function() {
+                return test_utils.list_indices();
+            })
+            .then(function(indices) {
+                var week_indices = indices.filter(function(index) {
+                    return index.substring(index.length - suffix.length) === suffix;
+                });
+
+                expect(week_indices.length).at.least(1);
+                var start = '2014-09-17T14:13:42.000Z';
+                var end = '2014-10-17T14:13:42.000Z';
+                return test_utils.read(start, end, 'local', '', interval);
+            })
+            .then(function(result) {
+                test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected_points, 'bytes');
+            });
+    }
+
+    it('writes and reads with weekly indexes', function() {
+        return check('week', '2014.38');
+    });
+
+    it('writes and reads with monthly indexes', function() {
+        return check('month', '2014.09');
+    });
+
+    it('writes and reads with yearly indexes', function() {
+        return check('year', '2014');
+    });
+
+    it('writes and reads with one index', function() {
+        return check('none', '');
+    });
+
+    it('errors on bogus interval', function() {
+        var message = 'invalid interval: bananas; accepted intervals are "day", "week", "month" "year", and "none"';
+        return Promise.all([
+            test_utils.expect_to_fail(test_utils.read_all('local', '', 'bananas'), message),
+            test_utils.expect_to_fail(test_utils.write(points_to_write, 'local', 'bananas'), message)
+        ]);
+    });
+});


### PR DESCRIPTION
Now you can read and write from weekly, monthly, yearly,
or singular indices by specifying -index_interval in
read commands or configuration.