### PR TITLE
read/write -timeField

### DIFF
--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -72,9 +72,9 @@ function _client_for_id(id) {
     }
 }
 
-function get_inserter(id, index, interval) {
+function get_inserter(id, index, interval, timeField) {
     var client = _client_for_id(id);
-    return new Inserter(client, index, interval);
+    return new Inserter(client, index, interval, timeField);
 }
 
 function fetcher(id, filter, query_start, query_end, options) {

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -37,17 +37,18 @@ function validate_event(event) {
     }
 }
 
-function EventsInserter(client, index, interval) {
+function EventsInserter(client, index, interval, timeField) {
     this.client = client;
     this.events = [];
     this.index = index;
     this.interval = interval;
+    this.timeField = timeField;
 }
 
 EventsInserter.prototype.push = function(event) {
     validate_event(event);
     var ts = normalize_timestamp(event.time);
-    event['@timestamp'] = ts.toISOString();
+    event[this.timeField] = ts.toISOString();
 
     this.events.push({
         index: {

--- a/lib/query.js
+++ b/lib/query.js
@@ -11,18 +11,17 @@ var es_errors = require('./es-errors');
 var DEFAULT_FETCH_SIZE;
 var DEFAULT_DEEP_PAGING_LIMIT;
 
-function make_body(filter, from, to, direction, tm_filter, size) {
+function make_body(filter, from, to, direction, tm_filter, size, timeField) {
     if (!tm_filter) {
-        tm_filter = _logstash_time_filter(from, to);
+        tm_filter = _time_filter(from, to, timeField);
     }
     var sort_params = {
         unmapped_type: 'date',
         order: direction
     };
 
-    var sort = {
-        '@timestamp': sort_params
-    };
+    var sort = {};
+    sort[timeField] = sort_params;
 
     return {
         from: 0,
@@ -41,6 +40,7 @@ function fetcher(client, filter, query_start, query_end, options) {
     var bridge_offset = 0;
     var points_emitted_so_far = 0;
     var limit = options.limit;
+    var timeField = options.timeField;
     var direction = options.direction || 'asc';
 
     var fetch_size = options.fetch_size || DEFAULT_FETCH_SIZE;
@@ -58,7 +58,7 @@ function fetcher(client, filter, query_start, query_end, options) {
             throw new Error(message);
         }
 
-        var points = utils.pointsFromESDocs(result.hits.hits);
+        var points = utils.pointsFromESDocs(result.hits.hits, timeField);
 
         if (direction === 'desc') {
             points.reverse();
@@ -88,14 +88,11 @@ function fetcher(client, filter, query_start, query_end, options) {
         var bridge_date = new Date(last_seen_timestamp);
         var bridge_time = new JuttleMoment({rawDate: bridge_date});
 
-        var logstash_time_filter = {
-            term: {
-                '@timestamp': bridge_time.valueOf()
-            }
-        };
+        var time_filter = {term: {}};
+        time_filter.term[timeField] = bridge_time.valueOf();
 
         var size = _get_body_size();
-        var body = make_body(filter, null, null, direction, logstash_time_filter, size);
+        var body = make_body(filter, null, null, direction, time_filter, size, timeField);
         body.from = bridge_offset;
 
         if (bridge_offset > deep_paging_limit) {
@@ -152,7 +149,7 @@ function fetcher(client, filter, query_start, query_end, options) {
                 return bridge_fetch();
             } else {
                 var size = _get_body_size();
-                var body = make_body(filter, query_start, query_end, direction, null, size);
+                var body = make_body(filter, query_start, query_end, direction, null, size, timeField);
 
                 return common.search(client, indices, body)
                     .then(function(result) {
@@ -185,6 +182,7 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
     var indices = options.indices;
     var aggregations = options.aggregations;
     var reduce_every = aggregations.reduce_every;
+    var timeField = options.timeField;
 
     function get_batch_offset_as_duration(every_duration) {
         try {
@@ -249,7 +247,7 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
             throw new Error('aggregation fetcher didn\'t have from/to');
         }
 
-        var query_body = make_body(filter, from, to, 'asc', null, 0);
+        var query_body = make_body(filter, from, to, 'asc', null, 0, timeField);
 
         query_body.aggregations = aggregations.es_aggr;
 
@@ -321,7 +319,7 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
     return Promise.resolve(fetcher);
 }
 
-function _logstash_time_filter(from, to) {
+function _time_filter(from, to, timeField) {
     var time = {};
 
     if (!from.isBeginning()) {
@@ -332,11 +330,9 @@ function _logstash_time_filter(from, to) {
         time.lt = to.valueOf();
     }
 
-    var filter = {
-        range: {
-            '@timestamp' : time
-        }
-    };
+    var filter = {range: {}};
+    filter.range[timeField] = time;
+
     return filter;
 }
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -12,6 +12,7 @@ var Read = Juttle.proc.source.extend({
 
     initialize: function(options, params) {
         this.id = options.id;
+        this.timeField = options.timeField || utils.default_time_field_for_id(this.id);
         this._setup_time_filter(options);
         this._setup_index(options);
         var filter_ast = params.filter_ast;
@@ -26,6 +27,7 @@ var Read = Juttle.proc.source.extend({
         this.es_opts = {
             indices: this.index,
             interval: this.interval,
+            timeField: this.timeField,
             limit: optimization_info.limit,
             aggregations: optimization_info.aggregations
         };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,15 +3,17 @@ var current_week_number = require('current-week-number');
 
 var DEFAULT_INDEXES = {};
 var DEFAULT_INTERVALS = {};
+var DEFAULT_TIME_FIELDS = {};
 var DEFAULT_DEFAULT_READ_INDEX = '*';
 var DEFAULT_DEFAULT_WRITE_INDEX = 'juttle';
 var DEFAULT_DEFAULT_INTERVAL = 'none';
+var DEFAULT_DEFAULT_TIME_FIELD = '@timestamp';
 
-function pointsFromESDocs(hits) {
+function pointsFromESDocs(hits, timeField) {
     return hits.map(function(hit) {
         var point = hit._source;
-        var time = new Date(point['@timestamp']).getTime();
-        var newPoint = _.omit(point, '@timestamp');
+        var time = new Date(point[timeField]).getTime();
+        var newPoint = _.omit(point, timeField);
         newPoint.time = time;
 
         return newPoint;
@@ -64,6 +66,10 @@ function init(config) {
             if (entry.hasOwnProperty('indexInterval')) {
                 DEFAULT_INTERVALS[entry.id] = entry.indexInterval;
             }
+
+            if (entry.hasOwnProperty('timeField')) {
+                DEFAULT_TIME_FIELDS[entry.id] = entry.timeField;
+            }
         }
     });
 }
@@ -71,6 +77,7 @@ function init(config) {
 var default_read_index_for_id = _default_for_id(DEFAULT_INDEXES, DEFAULT_DEFAULT_READ_INDEX);
 var default_write_index_for_id = _default_for_id(DEFAULT_INDEXES, DEFAULT_DEFAULT_WRITE_INDEX);
 var default_interval_for_id = _default_for_id(DEFAULT_INTERVALS, DEFAULT_DEFAULT_INTERVAL);
+var default_time_field_for_id = _default_for_id(DEFAULT_TIME_FIELDS, DEFAULT_DEFAULT_TIME_FIELD);
 
 function _default_for_id(defaults_object, default_default) {
     return function(id) {
@@ -97,5 +104,6 @@ module.exports = {
     default_read_index_for_id: default_read_index_for_id,
     default_write_index_for_id: default_write_index_for_id,
     default_interval_for_id: default_interval_for_id,
+    default_time_field_for_id: default_time_field_for_id,
     ensure_valid_interval: ensure_valid_interval,
 };

--- a/lib/write.js
+++ b/lib/write.js
@@ -9,11 +9,12 @@ var Write = Juttle.proc.sink.extend({
         this.eofs = 0;
         this.id = options.id;
         this.in_progress_writes = 0;
+        this.timeField = options.timeField || utils.default_time_field_for_id(this.id);
         this._setup_index(options);
     },
     process: function(points) {
         var self = this;
-        var inserter = elastic.get_inserter(this.id, this.index, this.interval);
+        var inserter = elastic.get_inserter(this.id, this.index, this.interval, this.timeField);
         for (var i = 0; i < points.length; i++) {
             try {
                 inserter.push(points[i]);


### PR DESCRIPTION
connects to #25 

Now the point that the adapter will use as a timestamp for documents in
ES is configurable by the time_field option. Juttle points still have
"time", this just determines the name of the field that the adapter will
put pt.time in when writing and put into pt.time when reading.

@demmer @VladVega @go-oleg @dmehra @rlgomes @henridf