### PR TITLE
Drop sourceType property from read

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -6,7 +6,6 @@ var utils = require('./utils');
 
 var Read = Juttle.proc.source.extend({
     procName: 'elastic_read',
-    sourceType: 'batch',
 
     initialize: function(options, params) {
         this.id = options.id;


### PR DESCRIPTION
As read now inherits from Juttle source proc and program checks for
that, the sourceType property is not needed.

refs: https://github.com/juttle/juttle/pull/110