### PR TITLE
filter-es-compiler: update to juttle 0.2.0 AST node types

### DIFF
--- a/lib/filter-es-compiler.js
+++ b/lib/filter-es-compiler.js
@@ -57,11 +57,11 @@ var FilterESCompiler = ASTVisitor.extend({
         return node.value;
     },
 
-    visitMomentConstant: function(node) {
+    visitMomentLiteral: function(node) {
         return node.value;
     },
 
-    visitDurationConstant: function(node) {
+    visitDurationLiteral: function(node) {
         return JuttleMoment.duration(node.value).seconds();
     },
 

--- a/test/elastic-adapter.spec.js
+++ b/test/elastic-adapter.spec.js
@@ -105,6 +105,22 @@ describe('elastic source', function() {
                 });
             });
 
+            it('compiles moments in filter expressions', function() {
+                return test_utils.read_all(type, 'client_ip != :5 minutes ago:')
+                    .then(function(result) {
+                        expect(result.errors).deep.equal([]);
+                        test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected_points, 'bytes');
+                    });
+            });
+
+            it('compiles durations in filter expressions', function() {
+                return test_utils.read_all(type, 'client_ip != :5 minutes:')
+                    .then(function(result) {
+                        expect(result.errors).deep.equal([]);
+                        test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected_points, 'bytes');
+                    });
+            });
+
             it('counts points', function() {
                 var start = '2014-09-17T14:13:42.000Z';
                 var end = '2014-09-17T14:13:43.000Z';


### PR DESCRIPTION
The AST nodes MomentConstant and DurationConstant were renamed to
MomentLiteral and DurationLiteral, so update the filter compiler
accordingly.

I noticed this same problem in https://github.com/juttle/juttle-sql-adapter-common/pull/6.

Also there should really be a test for this but I'm not familiar enough with how the data is put into ES in the unit test framework.

@davidvgalbraith could you consider adding a test to ensure we do the right thing when moment / duration literals are in the filter expressions?
