### PR TITLE
Ensure lint failures are travis failures.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "mocha",
     "jshint": "jshint **/*.js",
     "style": "jscs **/*.js",
-    "lint": "npm run jshint & npm run style"
+    "lint": "npm run jshint && npm run style"
   },
   "dependencies": {
     "aws-es": "juttle/aws-es.git",


### PR DESCRIPTION
Add missing && which was messing with the return value from the jshint
command.

@mnibecker you're an expert on this now!