### PR TITLE
write: relax constraints

### DIFF
--- a/lib/insert.js
+++ b/lib/insert.js
@@ -5,8 +5,6 @@ var Promise = require('bluebird');
 var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
 var utils = require('./utils');
 
-var ES_MAX_FIELD_LENGTH = 32766;
-
 function normalize_timestamp(ts) {
     var parsed = (typeof ts === 'string') ? Date.parse(ts) : ts;
 
@@ -24,16 +22,6 @@ function validate_event(event) {
 
     if (event.time instanceof JuttleMoment) {
         event.time = event.time.toJSON();
-    }
-
-    for (var key in event) {
-        var value = event[key];
-        if (_.isObject(value)) {
-            throw new Error('invalid event - value is an object or array ' + key + ' : ' + value);
-        } else if (value && typeof value === 'string' && value.length > ES_MAX_FIELD_LENGTH) {
-            var too_big_suffix = util.format('** FIELD TRUNCATED BY JUT (max length = %d)** ', ES_MAX_FIELD_LENGTH);
-            event[key] = value.substring(0, ES_MAX_FIELD_LENGTH - too_big_suffix.length) + too_big_suffix;
-        }
     }
 }
 
@@ -62,14 +50,36 @@ EventsInserter.prototype.push = function(event) {
 
 EventsInserter.prototype.end = function() {
     var self = this;
+    var errors = [];
     if (this.events.length === 0) {
-        return Promise.resolve();
+        return Promise.resolve(errors);
     }
 
     return this.client.bulkAsync({
         index: '', // aws-es demands index/type which is totally meaningless here
         type: '',
         body: this.events
+    })
+    .then(function(response) {
+        var result;
+
+        // aws-es returns an object while official ES client returns an array
+        if (Array.isArray(response)) {
+            result = response[0];
+        } else {
+            result = response;
+        }
+
+        if (result.errors) {
+            result.items.forEach(function(item) {
+                var info = item.create || item.index;
+                if (info.error) {
+                    errors.push(info.error.reason);
+                }
+            });
+        }
+
+        return errors;
     });
 };
 

--- a/lib/write.js
+++ b/lib/write.js
@@ -24,6 +24,12 @@ var Write = Juttle.proc.sink.extend({
         }
         self.in_progress_writes++;
         inserter.end()
+        .then(function(errors) {
+            errors.forEach(function(err) {
+                var message = 'point rejected by Elasticsearch due to: ' + err;
+                self.trigger('error', new Error(message));
+            });
+        })
         .catch(function(err) {
             var message = err.message === 'No Living connections' ? 'Failed to connect to Elasticsearch' : err.message;
             self.trigger('error', new Error('insertion failed: ' + message));


### PR DESCRIPTION
-Allow nested objects
-Allow long fields

Add some extra error handling to validate bulk responses

Fixes https://github.com/juttle/juttle-elastic-adapter/issues/33. 

@demmer @VladVega 