### PR TITLE
read: return empty aggregation result if no data

### DIFF
--- a/lib/es-errors.js
+++ b/lib/es-errors.js
@@ -7,8 +7,6 @@ var MissingField = Base.inherits(Error, {
     }
 });
 
-var MissingIndex = Base.inherits(Error, {});
-
 var _MISSING_FIELD_PATTERN = /No field found for \[([^\]]+)\] in mapping/;
 var _GROOVY_PATTERN = /groovy_script_execution_exception/;
 var _MISSING_INDEX_PATTERN = /index_not_found_exception/;
@@ -31,10 +29,6 @@ function categorize_error(error) {
         }
     }
 
-    if (str.match(_MISSING_INDEX_PATTERN) || str.match(_OLD_MISSING_INDEX_PATTERN)) {
-        return new MissingIndex();
-    }
-
     var overflow_match = str.match(_WINDOW_OVERFLOW_PATTERN);
     if (overflow_match) {
         var m = 'Tried to read more than %s points with the same timestamp, ' +
@@ -49,5 +43,4 @@ function categorize_error(error) {
 module.exports = {
     categorize_error: categorize_error,
     MissingField: MissingField,
-    MissingIndex: MissingIndex,
 };

--- a/lib/query-common.js
+++ b/lib/query-common.js
@@ -72,14 +72,7 @@ function search(client, indices, type, body) {
     })
     .catch(function(err) {
         var categorized = errors.categorize_error(err);
-        if (categorized instanceof errors.MissingIndex) {
-            return {
-                hits: {
-                    total: 0,
-                    hits: []
-                }
-            };
-        } else if (categorized) {
+        if (categorized) {
             throw categorized;
         } else {
             throw new Error(err.message);

--- a/test/elastic-adapter.spec.js
+++ b/test/elastic-adapter.spec.js
@@ -37,6 +37,10 @@ describe('elastic source', function() {
                 .then(function(result) {
                     expect(result.sinks.table).deep.equal([]);
                     expect(result.errors).deep.equal([]);
+                    return test_utils.read({from: '1 minute ago', to: 'now', id: type}, '| reduce count()');
+                })
+                .then(function(result) {
+                    expect(result.sinks.table).deep.equal([{count: 0}]);
                 });
             });
 


### PR DESCRIPTION
fixes https://github.com/juttle/juttle-elastic-adapter/issues/38

Also, the old code path for empty results used to catch index 404
errors from ES and return empty results in that case, but we use the
ignoreUnavailable query parameter so those 404s don't show up anymore.

@demmer @VladVega 