### PR TITLE
read/write: -idField

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Name | Type | Required | Description | Default
 `indexInterval` | string | no | granularity of an index. valid options: `day`, `week`, `month`, `year`, `none` | `none`
 `type` | string | no | [document type](https://www.elastic.co/guide/en/elasticsearch/guide/current/mapping.html) to read from | all types
 `timeField` | string | no | field containing timestamps | `@timestamp`
+`idField` | string | no | if specified, the value of this field in each point emitted by `read elastic` will be the [document ID](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html) of the corresponding Elasticsearch document | none
 
 ### Write options
 
@@ -114,6 +115,7 @@ Name | Type | Required | Description | Default
 `indexInterval` | string | no | granularity of an index. valid options: `day` `week`, `month`, `year`, `none` | `none`
 `type` | string | no | document type to write to | `event`
 `timeField` | string | no | field containing timestamps | `@timestamp`
+`idField` | string | no | if specified, the value of this field on each point will be used as the document ID for the corresponding Elasticsearch document and not stored | none
 
 ## Contributing
 

--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -72,9 +72,9 @@ function _client_for_id(id) {
     }
 }
 
-function get_inserter(id, index, type, interval, timeField) {
-    var client = _client_for_id(id);
-    return new Inserter(client, index, type, interval, timeField);
+function get_inserter(options) {
+    var client = _client_for_id(options.id);
+    return new Inserter(client, options);
 }
 
 function fetcher(id, filter, query_start, query_end, options) {

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -25,22 +25,29 @@ function validate_event(event) {
     }
 }
 
-function EventsInserter(client, index, type, interval, timeField) {
+function EventsInserter(client, options) {
     this.client = client;
     this.events = [];
-    this.index = index;
-    this.type = type;
-    this.interval = interval;
-    this.timeField = timeField;
+    this.index = options.index;
+    this.type = options.type;
+    this.interval = options.interval;
+    this.timeField = options.timeField;
+    this.idField = options.idField;
 }
 
 EventsInserter.prototype.push = function(event) {
     validate_event(event);
     var ts = normalize_timestamp(event.time);
     event[this.timeField] = ts.toISOString();
+    var _id;
+    if (this.idField && event[this.idField]) {
+        _id = event[this.idField];
+        event[this.idField] = undefined;
+    }
 
     this.events.push({
         index: {
+            _id: _id,
             _index: utils.index_name(ts, this.index, this.interval),
             _type: this.type
         }

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -80,6 +80,12 @@ var optimizer = {
             return false;
         }
 
+        var id_field = graph.node_get_option(read, 'idField');
+        if (_.contains(groupby, id_field)) {
+            logger.debug('optimization aborting -- cannot optimize reduce by -idField');
+            return false;
+        }
+
         var forget = graph.node_get_option(reduce, 'forget');
         if (forget === false) {
             logger.debug('optimization aborting -- cannot optimize -forget false');

--- a/lib/query.js
+++ b/lib/query.js
@@ -42,6 +42,7 @@ function fetcher(client, filter, query_start, query_end, options) {
     var points_emitted_so_far = 0;
     var limit = options.limit;
     var timeField = options.timeField;
+    var idField = options.idField;
     var direction = options.direction || 'asc';
 
     var fetch_size = options.fetch_size || DEFAULT_FETCH_SIZE;
@@ -59,7 +60,7 @@ function fetcher(client, filter, query_start, query_end, options) {
             throw new Error(message);
         }
 
-        var points = utils.pointsFromESDocs(result.hits.hits, timeField);
+        var points = utils.pointsFromESDocs(result.hits.hits, timeField, idField);
 
         if (direction === 'desc') {
             points.reverse();

--- a/lib/read.js
+++ b/lib/read.js
@@ -12,8 +12,9 @@ var Read = Juttle.proc.source.extend({
 
     initialize: function(options, params) {
         this.id = options.id;
-        this.timeField = options.timeField || utils.default_config_property_for_id(this.id, 'timeField');
-        this.type = options.type || utils.default_config_property_for_id(this.id, 'readType');
+        this.timeField = options.timeField || this._default_config('timeField');
+        this.type = options.type || this._default_config('readType');
+        this.idField = options.idField || this._default_config('idField');
 
         this._setup_time_filter(options);
         this._setup_index(options);
@@ -31,6 +32,7 @@ var Read = Juttle.proc.source.extend({
             type: this.type,
             interval: this.interval,
             timeField: this.timeField,
+            idField: this.idField,
             limit: optimization_info.limit,
             aggregations: optimization_info.aggregations
         };
@@ -44,9 +46,13 @@ var Read = Juttle.proc.source.extend({
         }
     },
 
+    _default_config: function(property) {
+        return utils.default_config_property_for_id(this.id, property);
+    },
+
     _setup_index: function(options) {
-        this.index = options.index || utils.default_config_property_for_id(this.id, 'readIndex');
-        this.interval = options.indexInterval || utils.default_config_property_for_id(this.id, 'indexInterval');
+        this.index = options.index || this._default_config('readIndex');
+        this.interval = options.indexInterval || this._default_config('indexInterval');
         utils.ensure_valid_interval(this.interval);
         if (this.interval !== 'none') {
             if (_.last(this.index) !== '*') {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,18 +6,23 @@ var DEFAULT_CONFIG = {
     writeIndex: 'juttle',
     indexInterval: 'none',
     timeField: '@timestamp',
+    idField: undefined,
     writeType: 'event',
     readType: ''
 };
 
 var CONFIG = {};
 
-function pointsFromESDocs(hits, timeField) {
+function pointsFromESDocs(hits, timeField, idField) {
     return hits.map(function(hit) {
         var point = hit._source;
         var time = new Date(point[timeField]).getTime();
         var newPoint = _.omit(point, timeField);
         newPoint.time = time;
+
+        if (idField) {
+            newPoint[idField] = hit._id;
+        }
 
         return newPoint;
     });

--- a/lib/write.js
+++ b/lib/write.js
@@ -1,3 +1,5 @@
+var _ = require('underscore');
+
 var elastic = require('./elastic');
 var Juttle = require('juttle/lib/runtime').Juttle;
 var utils = require('./utils');
@@ -8,14 +10,16 @@ var Write = Juttle.proc.sink.extend({
         var self = this;
         this.eofs = 0;
         this.id = options.id;
-        this.type = options.type || utils.default_config_property_for_id(this.id, 'writeType');
+        this.type = options.type || this._default_config('writeType');
         this.in_progress_writes = 0;
-        this.timeField = options.timeField || utils.default_config_property_for_id(this.id, 'timeField');
+        this.timeField = options.timeField || this._default_config('timeField');
+        this.idField = options.idField || this._default_config('idField');
         this._setup_index(options);
     },
     process: function(points) {
         var self = this;
-        var inserter = elastic.get_inserter(this.id, this.index, this.type, this.interval, this.timeField);
+        var inserter_options = _.pick(this, 'id', 'index', 'type', 'interval', 'timeField', 'idField');
+        var inserter = elastic.get_inserter(inserter_options);
         for (var i = 0; i < points.length; i++) {
             try {
                 inserter.push(points[i]);
@@ -41,9 +45,13 @@ var Write = Juttle.proc.sink.extend({
         });
     },
 
+    _default_config: function(property) {
+        return utils.default_config_property_for_id(this.id, property);
+    },
+
     _setup_index: function(options) {
-        var index = options.index || utils.default_config_property_for_id(this.id, 'writeIndex');
-        this.interval = options.indexInterval || utils.default_config_property_for_id(this.id, 'indexInterval');
+        var index = options.index || this._default_config('writeIndex');
+        this.interval = options.indexInterval || this._default_config('indexInterval');
         utils.ensure_valid_interval(this.interval);
 
         var star_index = index.indexOf('*');


### PR DESCRIPTION
With read elastic -idField, the _id field of each document in Elasticsearch
will be written into the value of the -idField option if specified.
With write elastic -idField, the value of each point's `idField` is used
as the _id of the corresponding document in Elasticsearch.

fixes https://github.com/juttle/juttle-elastic-adapter/issues/32

@demmer @VladVega 