### PR TITLE
Bring back date histograms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,14 @@ addons:
 before_install:
     - export CXX="g++-4.8"
     - npm install juttle@0.2.x
+    - curl -L -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.1.1/elasticsearch-2.1.1.tar.gz
+    - tar -xvf elasticsearch-2.1.1.tar.gz
+    - rm elasticsearch-2.1.1.tar.gz
+    - ./elasticsearch-2.1.1/bin/elasticsearch &
 
 node_js:
     - '4.2'
     - '5.0'
-
-services:
-    - elasticsearch
 
 before_script:
     - npm install -g jshint

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/juttle/juttle-elastic-adapter.svg)](https://travis-ci.org/juttle/juttle-elastic-adapter)
 
-The Juttle Elastic Adapter enables reading and writing documents using [Elasticsearch](https://www.elastic.co/products/elasticsearch).
+The Juttle Elastic Adapter enables reading and writing documents using [Elasticsearch](https://www.elastic.co/products/elasticsearch). It works with Elasticsearch version 2.0 and above.
 
 ## Examples
 

--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -99,6 +99,29 @@ function make_bucket_agg(groupby, subagg, every, logstash) {
     return { group: agg };
 }
 
+// build an elasticsearch date histogram aggregation.
+// every and on are moments corresponding to the -every
+// and -on arguments to batch or reduce.  subagg is a
+// dictionary of sub-aggregations to be run in each time bucket.
+// (the results of previous called to make_reducer_agg() )
+function make_datehist_agg(every, on, subagg) {
+    var histogram = {
+        field: 'time',
+        interval: every.milliseconds() + 'ms',
+    };
+
+    if (on) {
+        histogram.offset = on.milliseconds() + 'ms';
+    }
+
+    return {
+        _time: {
+            date_histogram: histogram,
+            aggregations: subagg
+        }
+    };
+}
+
 // as mentioned above in make_bucket_agg(), when we group by multiple
 // fields at once, we use a script written in groovy to build a string
 // representation of the values of all the grouping fields and then do
@@ -331,5 +354,6 @@ module.exports = {
     make_reducer_agg: make_reducer_agg,
     make_bucket_agg: make_bucket_agg,
     remove_field: remove_field,
+    make_datehist_agg: make_datehist_agg,
     values_from_es_aggr_resp: values_from_es_aggr_resp
 };

--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -108,6 +108,7 @@ function make_datehist_agg(every, on, subagg) {
     var histogram = {
         field: 'time',
         interval: every.milliseconds() + 'ms',
+        min_doc_count: 0
     };
 
     if (on) {
@@ -304,8 +305,7 @@ function values_from_es_aggr_resp(response, info) {
         _.each(result.group.buckets, function(bucket) {
             if (info.grouping.length === 1) {
                 proto[info.grouping[0]] = bucket.key;
-            }
-            else {
+            } else {
                 var L = _parse_aggkey(bucket.key);
                 if (L.length !== info.grouping.length) {
                     var msg = 'malformed agg key' +
@@ -332,8 +332,7 @@ function values_from_es_aggr_resp(response, info) {
             rv = _.sortBy(rv, 'time');
         }
         return rv;
-    }
-    else {
+    } else {
         var pts = do_leaf(result, proto, false);
         if (info.count && !_.has(result, '_time')) {
             pts[0][info.count] = response.hits.total;

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -5,7 +5,6 @@ var aggregation = require('./aggregation');
 
 var logger = require('juttle/lib/logger').getLogger('elastic-optimize');
 var ALLOWED_REDUCE_OPTIONS = ['every', 'forget', 'groupby', 'on'];
-var MANY_BUCKETS = 1000;
 
 function _getFieldName(node) {
     return node.expression.value;
@@ -46,21 +45,6 @@ function reduce_expr_is_optimizable(expr) {
     }
 
     return true;
-}
-
-function _get_read_duration(read, graph) {
-    if (graph.node_has_option(read, 'last')) {
-        return graph.node_get_option(read, 'last').milliseconds();
-    } else {
-        return graph.node_get_option(read, 'to').subtract(graph.node_get_option(read, 'from')).milliseconds();
-    }
-}
-
-function _get_bucket_count(read, reduce, graph) {
-    var bucket_duration = graph.node_get_option(reduce, 'every').milliseconds();
-    var read_duration = _get_read_duration(read, graph);
-
-    return read_duration / bucket_duration;
 }
 
 var optimizer = {
@@ -110,7 +94,7 @@ var optimizer = {
 
         var aggrs = {};
         var aggr_names = [];
-        var count_name, every, on, had_many_buckets;
+        var count_name, every, on;
 
         for (var i = 0; i < reduce.exprs.length; i++) {
             var expr = reduce.exprs[i];
@@ -150,10 +134,6 @@ var optimizer = {
 
         var empty_result = _.object(reduce.exprs.map(_empty_reducer_result));
 
-        if (grouped) {
-            aggrs = aggregation.make_bucket_agg(groupby, aggrs);
-        }
-
         if (graph.node_has_option(reduce, 'every')) {
             every = graph.node_get_option(reduce, 'every');
             on = graph.node_get_option(reduce, 'on');
@@ -161,11 +141,12 @@ var optimizer = {
                 logger.debug('optimization aborting -- cannot optimize calendar -every');
                 return false;
             }
-            var num_buckets = _get_bucket_count(read, reduce, graph);
-            if (num_buckets > MANY_BUCKETS) {
-                aggrs = aggregation.make_datehist_agg(every, on, aggrs);
-                had_many_buckets = true;
-            }
+
+            aggrs = aggregation.make_datehist_agg(every, on, aggrs);
+        }
+
+        if (grouped) {
+            aggrs = aggregation.make_bucket_agg(groupby, aggrs);
         }
 
         _.extend(optimization_info, {
@@ -177,7 +158,6 @@ var optimizer = {
                 empty_result: empty_result,
                 empty_fields: [],
                 grouping: groupby,
-                had_many_buckets: had_many_buckets,
                 reduce_every: every,
                 reduce_on: on
             }

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -5,6 +5,7 @@ var aggregation = require('./aggregation');
 
 var logger = require('juttle/lib/logger').getLogger('elastic-optimize');
 var ALLOWED_REDUCE_OPTIONS = ['every', 'forget', 'groupby', 'on'];
+var MANY_BUCKETS = 1000;
 
 function _getFieldName(node) {
     return node.expression.value;
@@ -45,6 +46,21 @@ function reduce_expr_is_optimizable(expr) {
     }
 
     return true;
+}
+
+function _get_read_duration(read, graph) {
+    if (graph.node_has_option(read, 'last')) {
+        return graph.node_get_option(read, 'last').milliseconds();
+    } else {
+        return graph.node_get_option(read, 'to').subtract(graph.node_get_option(read, 'from')).milliseconds();
+    }
+}
+
+function _get_bucket_count(read, reduce, graph) {
+    var bucket_duration = graph.node_get_option(reduce, 'every').milliseconds();
+    var read_duration = _get_read_duration(read, graph);
+
+    return read_duration / bucket_duration;
 }
 
 var optimizer = {
@@ -94,7 +110,7 @@ var optimizer = {
 
         var aggrs = {};
         var aggr_names = [];
-        var count_name, every, on;
+        var count_name, every, on, had_many_buckets;
 
         for (var i = 0; i < reduce.exprs.length; i++) {
             var expr = reduce.exprs[i];
@@ -145,6 +161,11 @@ var optimizer = {
                 logger.debug('optimization aborting -- cannot optimize calendar -every');
                 return false;
             }
+            var num_buckets = _get_bucket_count(read, reduce, graph);
+            if (num_buckets > MANY_BUCKETS) {
+                aggrs = aggregation.make_datehist_agg(every, on, aggrs);
+                had_many_buckets = true;
+            }
         }
 
         _.extend(optimization_info, {
@@ -156,6 +177,7 @@ var optimizer = {
                 empty_result: empty_result,
                 empty_fields: [],
                 grouping: groupby,
+                had_many_buckets: had_many_buckets,
                 reduce_every: every,
                 reduce_on: on
             }

--- a/lib/query.js
+++ b/lib/query.js
@@ -186,7 +186,6 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
     var aggregations = options.aggregations;
     var reduce_every = aggregations.reduce_every ? new JuttleMoment.duration(aggregations.reduce_every) : null;
     var timeField = options.timeField;
-    var had_many_buckets = aggregations.had_many_buckets;
 
     function get_batch_offset_as_duration(every_duration) {
         try {
@@ -201,12 +200,10 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
     }
 
     function get_buckets() {
-        // batched aggregations are done one batch at a time
-        // to prevent ES from blowing up, so here we get the list of
-        // batches we are going to do. Unbatched aggregations
+        // batched aggregations are done 1000 batches at a time for flow control
         // are just executed as though they were single-batch batch queries
         var buckets = [query_start];
-        if (reduce_every && !had_many_buckets) {
+        if (reduce_every) {
             var zeroth_bucket = JuttleMoment.quantize(query_start, reduce_every);
             var last_bucket = JuttleMoment.quantize(query_end, reduce_every);
 
@@ -217,11 +214,13 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
                 last_bucket = last_bucket.add(offset);
             }
 
-            var intermediate_bucket = zeroth_bucket.add(reduce_every);
+            var intermediate_bucket = zeroth_bucket;
+            var buckets_delta = reduce_every.multiply(1000);
 
-            while (intermediate_bucket.lte(last_bucket)) {
+            while (intermediate_bucket.lt(last_bucket)) {
+                var next_bucket = intermediate_bucket.add(buckets_delta);
+                intermediate_bucket = JuttleMoment.min(next_bucket, last_bucket);
                 buckets.push(intermediate_bucket);
-                intermediate_bucket = intermediate_bucket.add(reduce_every);
             }
         }
 
@@ -231,8 +230,6 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
     }
 
     var buckets = get_buckets();
-    var has_emitted;
-    var buffered_empties = [];
 
     function fetcher() {
         var grouped = aggregations.grouping && aggregations.grouping.length > 0;
@@ -257,28 +254,11 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
         return common.search(client, indices, type, query_body)
         .then(function(response) {
             var total = response.hits && response.hits.total;
-            if (total === 0 && !grouped) {
-                if (has_emitted) {
-                    var pt = {};
-                    if (reduce_every) {
-                        pt.time = to;
-                    }
-
-                    buffered_empties.push(_.extend(pt, aggregations.empty_result));
-                }
-
-                return {
-                    points: [],
-                    eof: buckets.length === 1
-                };
-            }
-
             var aggr_points = juttle_utils.toNative(aggregation.values_from_es_aggr_resp(response, aggregations));
-
 
             // If points are timeful we make the timestamps epsilon moments,
             // just like they would be if they came out of reduce -every
-            // and if we had a lot of buckets then we performed a date histogram
+            // and add an interval since we performed a date histogram
             // aggregation which puts all the points a bucket behind
             if (reduce_every) {
                 if (to === query_end) {
@@ -286,31 +266,14 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
                 }
 
                 aggr_points.forEach(function format_aggregated_time(pt) {
-                    if (had_many_buckets) {
-                        pt.time = pt.time.add(reduce_every);
-                    } else {
-                        pt.time = to;
-                    }
-
+                    pt.time = pt.time.add(reduce_every);
                     pt.time.epsilon = true;
                 });
             }
 
-            if (grouped) {
-                var limit = aggregations.es_aggr.group.terms.size;
-                if (aggr_points.length === limit || (response.aggregations &&
-                    response.aggregations.group &&
-                    response.aggregations.group.buckets &&
-                    response.aggregations.group.buckets.length === limit)) {
-                }
-            }
-
-            var all_points = buffered_empties.concat(aggr_points);
-            buffered_empties = [];
-            has_emitted = true;
             return {
                 eof: buckets.length === 1, // last bucket is exclusive
-                points: all_points
+                points: aggr_points
             };
         })
         .catch(es_errors.MissingField, function(ex) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -110,7 +110,7 @@ function fetcher(client, filter, query_start, query_end, options) {
                     // (if it really is the end of the query then the non-brige-path
                     // will fetch one more empty batch and return eof)
                     should_execute_bridge_fetch = false;
-                    query_start = JuttleMoment.add(bridge_time, JuttleMoment.duration(1, 'milliseconds'));
+                    query_start = bridge_time.add(JuttleMoment.duration(1, 'milliseconds'));
                     processed.eof = false;
                 }
 
@@ -184,8 +184,9 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
     var indices = options.indices;
     var type = options.type;
     var aggregations = options.aggregations;
-    var reduce_every = aggregations.reduce_every;
+    var reduce_every = aggregations.reduce_every ? new JuttleMoment.duration(aggregations.reduce_every) : null;
     var timeField = options.timeField;
+    var had_many_buckets = aggregations.had_many_buckets;
 
     function get_batch_offset_as_duration(every_duration) {
         try {
@@ -205,23 +206,22 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
         // batches we are going to do. Unbatched aggregations
         // are just executed as though they were single-batch batch queries
         var buckets = [query_start];
-        if (reduce_every) {
-            var duration = new JuttleMoment.duration(reduce_every);
-            var zeroth_bucket = JuttleMoment.quantize(query_start, duration);
-            var last_bucket = JuttleMoment.quantize(query_end, duration);
+        if (reduce_every && !had_many_buckets) {
+            var zeroth_bucket = JuttleMoment.quantize(query_start, reduce_every);
+            var last_bucket = JuttleMoment.quantize(query_end, reduce_every);
 
             if (aggregations.reduce_on) {
-                var offset = get_batch_offset_as_duration(duration);
-                zeroth_bucket = JuttleMoment.add(zeroth_bucket, offset);
+                var offset = get_batch_offset_as_duration(reduce_every);
+                zeroth_bucket = zeroth_bucket.add(offset);
                 buckets.push(zeroth_bucket);
-                last_bucket = JuttleMoment.add(last_bucket, offset);
+                last_bucket = last_bucket.add(offset);
             }
 
-            var intermediate_bucket = JuttleMoment.add(zeroth_bucket, duration);
+            var intermediate_bucket = zeroth_bucket.add(reduce_every);
 
             while (intermediate_bucket.lte(last_bucket)) {
                 buckets.push(intermediate_bucket);
-                intermediate_bucket = JuttleMoment.add(intermediate_bucket, duration);
+                intermediate_bucket = intermediate_bucket.add(reduce_every);
             }
         }
 
@@ -275,21 +275,25 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
 
             var aggr_points = juttle_utils.toNative(aggregation.values_from_es_aggr_resp(response, aggregations));
 
-            if (reduce_every) {
-                aggr_points.forEach(function(pt) {
-                    if (to === query_end) {
-                        var duration = new JuttleMoment.duration(reduce_every);
-                        to = JuttleMoment.quantize(to, duration).add(duration);
-                    }
-                    pt.time = to;
-                });
-            }
 
-            // If points are timeful, this aggregation included a date
-            // histogram, so we make the timestamps epsilon moments, just
-            // like they would be if they came out of reduce -every
-            if (_.has(aggr_points[0], 'time')) {
-                _.each (aggr_points, function(pt) { pt.time.epsilon = true; });
+            // If points are timeful we make the timestamps epsilon moments,
+            // just like they would be if they came out of reduce -every
+            // and if we had a lot of buckets then we performed a date histogram
+            // aggregation which puts all the points a bucket behind
+            if (reduce_every) {
+                if (to === query_end) {
+                    to = JuttleMoment.quantize(to, reduce_every).add(reduce_every);
+                }
+
+                aggr_points.forEach(function format_aggregated_time(pt) {
+                    if (had_many_buckets) {
+                        pt.time = pt.time.add(reduce_every);
+                    } else {
+                        pt.time = to;
+                    }
+
+                    pt.time.epsilon = true;
+                });
             }
 
             if (grouped) {

--- a/test/optimization.spec.js
+++ b/test/optimization.spec.js
@@ -196,6 +196,24 @@ describe('optimization', function() {
                     return test_utils.check_optimization(start, end, type, extra);
                 });
 
+                it('optimizes reduce -every with a lot of buckets', function() {
+                    var extra = '| reduce -every :h: count()';
+                    return test_utils.check_optimization('10 years ago', 'now', type, extra);
+                });
+
+                it('optimizes reduce -every with a lot of buckets and nontrivial time filter', function() {
+                    var start = '2014-09-17T00:00:00.000Z';
+                    var end = '2014-09-17T14:13:46.000Z';
+                    var extra = '| reduce -every :s: count()';
+                    return test_utils.check_optimization(start, end, type, extra);
+                });
+
+                // travis runs outdated ES so we can't test this in the CI
+                it.skip('optimizes reduce -every -on with a lot of buckets', function() {
+                    var extra = '| reduce -every :h: -on :5m: count()';
+                    return test_utils.check_optimization('10 years ago', 'now', type, extra);
+                });
+
                 it('doesn\'t optimize reduce -acc true', function() {
                     return test_utils.read({from: start, to: end, id: type}, '| reduce -every :s: -acc true by clientip')
                         .then(function(result) {

--- a/test/optimization.spec.js
+++ b/test/optimization.spec.js
@@ -215,8 +215,7 @@ describe('optimization', function() {
                     return test_utils.check_optimization(start, end, type, extra);
                 });
 
-                // travis runs outdated ES so we can't test this in the CI
-                it.skip('optimizes reduce -every -on with a lot of buckets', function() {
+                it('optimizes reduce -every -on with a lot of buckets', function() {
                     var extra = '| reduce -every :h: -on :5m: count()';
                     return test_utils.check_optimization('10 years ago', 'now', type, extra);
                 });

--- a/test/optimization.spec.js
+++ b/test/optimization.spec.js
@@ -208,6 +208,13 @@ describe('optimization', function() {
                     return test_utils.check_optimization(start, end, type, extra);
                 });
 
+                it('optimizes reduce -every with a lot of buckets and nontrivial time filter', function() {
+                    var start = '2014-09-17T00:00:00.000Z';
+                    var end = '2014-09-20T00:00:00.000Z';
+                    var extra = '| reduce -every :day: count()';
+                    return test_utils.check_optimization(start, end, type, extra);
+                });
+
                 // travis runs outdated ES so we can't test this in the CI
                 it.skip('optimizes reduce -every -on with a lot of buckets', function() {
                     var extra = '| reduce -every :h: -on :5m: count()';


### PR DESCRIPTION
If there are >1000 buckets, do a date histogram instead of
proceeding bucket-by-bucket.

fixes https://github.com/juttle/juttle-elastic-adapter/issues/48

@demmer @VladVega 