### PR TITLE
Eliminate useless `emit_eof` call in `Write`

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -75,7 +75,6 @@ var Write = Juttle.proc.sink.extend({
 
     _maybe_done: function() {
         if (this.eofs === this.ins.length && this.in_progress_writes === 0) {
-            this.emit_eof();
             this.done();
         }
     },


### PR DESCRIPTION
The call is a noop (because `Write` is a sink).

See juttle/juttle#131.