### PR TITLE
Update to juttle 0.3.0 both in package.json and travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 before_install:
     - export CXX="g++-4.8"
-    - npm install juttle@0.2.x
+    - npm install juttle@0.3.x
     - curl -L -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.1.1/elasticsearch-2.1.1.tar.gz
     - tar -xvf elasticsearch-2.1.1.tar.gz
     - rm elasticsearch-2.1.1.tar.gz

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "underscore": "^1.8.3"
   },
   "peerDependencies": {
-    "juttle": "^0.2.0"
+    "juttle": ">=0.3.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
Using >= 0.3.0, the format used by other adapters.

@davidvgalbraith @demmer 