### PR TITLE
optimize tail

### DIFF
--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -64,6 +64,22 @@ var optimizer = {
         optimization_info.limit = limit;
         return true;
     },
+    optimize_tail: function(read, tail, graph, optimization_info) {
+        if (optimization_info.type && optimization_info.type !== 'tail') {
+            logger.debug('optimization aborting -- cannot append tail optimization to prior', optimization_info.type, 'optimization');
+            return false;
+        }
+
+        var limit = graph.node_get_option(tail, 'arg');
+
+        if (optimization_info.hasOwnProperty('limit')) {
+            limit = Math.min(limit, optimization_info.limit);
+        }
+
+        optimization_info.type = 'tail';
+        optimization_info.limit = limit;
+        return true;
+    },
     optimize_reduce: function(read, reduce, graph, optimization_info) {
         if (!graph.node_contains_only_options(reduce, ALLOWED_REDUCE_OPTIONS)) {
             logger.debug('optimization aborting -- cannot optimize reduce with options', graph.node_get_option_names(reduce));

--- a/lib/query.js
+++ b/lib/query.js
@@ -67,6 +67,7 @@ function fetcher(client, filter, query_start, query_end, options) {
 
         return {
             total: result.hits.total,
+            executed_query: request_body, // for tests
             points: points,
             eof: eof
         };
@@ -168,6 +169,7 @@ function fetcher(client, filter, query_start, query_end, options) {
     function null_fetcher() {
         return Promise.resolve({
             points: [],
+            executed_query: null,
             eof: true
         });
     }
@@ -236,6 +238,7 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
         if (buckets.length === 0) {
             return Promise.resolve({
                 points: [],
+                executed_query: null,
                 eof: true
             });
         }
@@ -272,6 +275,7 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
 
             return {
                 eof: buckets.length === 1, // last bucket is exclusive
+                executed_query: query_body, // for tests
                 points: aggr_points
             };
         })

--- a/lib/read.js
+++ b/lib/read.js
@@ -34,6 +34,7 @@ var Read = Juttle.proc.source.extend({
             timeField: this.timeField,
             idField: this.idField,
             limit: optimization_info.limit,
+            direction: optimization_info.type === 'tail' ? 'desc' : 'asc',
             aggregations: optimization_info.aggregations
         };
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -45,6 +45,8 @@ var Read = Juttle.proc.source.extend({
         if (options.deep_paging_limit) {
             this.es_opts.deep_paging_limit = options.deep_paging_limit;
         }
+
+        this.executed_queries = [];
     },
 
     _default_config: function(property) {
@@ -79,6 +81,13 @@ var Read = Juttle.proc.source.extend({
         }
     },
 
+    _stash_executed_query: function(result) {
+        // for tests, store the Elasticsearch query we executed
+        if (result.executed_query) {
+            this.executed_queries.push(result.executed_query);
+        }
+    },
+
     start: function() {
         var self = this;
         return elastic.fetcher(this.id, this.es_filter, this.from, this.to, this.es_opts)
@@ -86,6 +95,8 @@ var Read = Juttle.proc.source.extend({
                 function loop() {
                     return fetcher()
                         .then(function(result) {
+                            self._stash_executed_query(result);
+
                             if (result.points.length > 0) {
                                 self.emit(juttle_utils.toNative(result.points));
                             }

--- a/test/elastic-adapter-limits.js
+++ b/test/elastic-adapter-limits.js
@@ -62,6 +62,16 @@ describe('elastic source limits', function() {
                 });
             });
 
+            it('enforces tail across multiple fetches', function() {
+                var extra = '-fetch_size 2 | tail 4';
+                return test_utils.read({id: type}, extra)
+                .then(function(result) {
+                    var expected = _.last(points, 4);
+                    test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
+                    expect(result.prog.graph.es_opts.limit).equal(4);
+                });
+            });
+
             it('catches window errors and reports something usable', function() {
                 if (type === 'aws') {
                     // AWS's ES version doesn't have window overflow errors

--- a/test/optimization.spec.js
+++ b/test/optimization.spec.js
@@ -48,13 +48,18 @@ describe('optimization', function() {
                 });
             });
 
+            function expect_graph_has_limit(graph, limit) {
+                expect(graph.es_opts.limit).equal(limit);
+                expect(graph.executed_queries[0].size).equal(limit);
+            }
+
             describe('head', function() {
                 it('optimizes head', function() {
                     return test_utils.read({id: type}, '| head 3')
                     .then(function(result) {
                         var expected = points.slice(0, 3);
                         test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
-                        expect(result.prog.graph.es_opts.limit).equal(3);
+                        expect_graph_has_limit(result.prog.graph, 3);
                     });
                 });
 
@@ -68,7 +73,7 @@ describe('optimization', function() {
                         }).slice(0, 2);
 
                         test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
-                        expect(result.prog.graph.es_opts.limit).equal(2);
+                        expect_graph_has_limit(result.prog.graph, 2);
                     });
                 });
 
@@ -80,7 +85,7 @@ describe('optimization', function() {
                         }).slice(0, 2);
 
                         test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
-                        expect(result.prog.graph.es_opts.limit).equal(2);
+                        expect_graph_has_limit(result.prog.graph, 2);
                     });
                 });
 
@@ -99,7 +104,7 @@ describe('optimization', function() {
                     .then(function(result) {
                         var expected = _.last(points, 4);
                         test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
-                        expect(result.prog.graph.es_opts.limit).equal(4);
+                        expect_graph_has_limit(result.prog.graph, 4);
                     });
                 });
 
@@ -115,7 +120,7 @@ describe('optimization', function() {
                         var expected = _.last(points_in_range, 4);
 
                         test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
-                        expect(result.prog.graph.es_opts.limit).equal(4);
+                        expect_graph_has_limit(result.prog.graph, 4);
                     });
                 });
 
@@ -129,7 +134,7 @@ describe('optimization', function() {
                         var expected = _.last(points_in_range, 4);
 
                         test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
-                        expect(result.prog.graph.es_opts.limit).equal(4);
+                        expect_graph_has_limit(result.prog.graph, 4);
                     });
                 });
 
@@ -137,7 +142,7 @@ describe('optimization', function() {
                     return test_utils.read({id: type}, '| tail 0')
                     .then(function(result) {
                         expect(result.sinks.table).deep.equal([]);
-                        expect(result.prog.graph.es_opts.limit).equal(0);
+                        expect(result.prog.graph.executed_queries.length).equal(0);
                     });
                 });
 
@@ -146,14 +151,14 @@ describe('optimization', function() {
                         .then(function(result) {
                             var expected = _.last(points, 4);
                             test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
-                            expect(result.prog.graph.es_opts.limit).equal(4);
+                            expect_graph_has_limit(result.prog.graph, 4);
                         });
                 });
 
                 it('doesn\'t optimize over prior head optimization', function() {
                     return test_utils.read({id: type}, '| head 3 | tail 0', function() {
                         expect(result.sinks.table).deep.equal([]);
-                        expect(result.prog.graph.es_opts.limit).equal(3);
+                        expect_graph_has_limit(result.prog.graph, 3);
                     });
                 });
             });


### PR DESCRIPTION
All the read-sorting logic is already there from Jut 1.0, we
just have to turn it on by passing {direction: 'desc'} to query.js

Fixes https://github.com/juttle/juttle-elastic-adapter/issues/36

@VladVega @demmer 