### PR TITLE
tail: don't optimize beyond fetch_size

### DIFF
--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -5,6 +5,7 @@ var aggregation = require('./aggregation');
 
 var logger = require('juttle/lib/logger').getLogger('elastic-optimize');
 var ALLOWED_REDUCE_OPTIONS = ['every', 'forget', 'groupby', 'on'];
+var DEFAULT_FETCH_SIZE = require('./query').DEFAULT_FETCH_SIZE;
 
 function _getFieldName(node) {
     return node.expression.value;
@@ -74,6 +75,12 @@ var optimizer = {
 
         if (optimization_info.hasOwnProperty('limit')) {
             limit = Math.min(limit, optimization_info.limit);
+        }
+
+        var read_fetch_size = graph.node_get_option(read, 'fetch_size') || DEFAULT_FETCH_SIZE;
+        if (limit > read_fetch_size) {
+            logger.debug('optimization aborting -- cannot optimize tail limit over fetch size');
+            return false;
         }
 
         optimization_info.type = 'tail';

--- a/lib/query.js
+++ b/lib/query.js
@@ -8,7 +8,7 @@ var utils = require('./utils');
 var aggregation = require('./aggregation');
 var es_errors = require('./es-errors');
 
-var DEFAULT_FETCH_SIZE;
+var DEFAULT_FETCH_SIZE = 10000;
 var DEFAULT_DEEP_PAGING_LIMIT;
 
 function make_body(filter, from, to, direction, tm_filter, size, timeField) {
@@ -310,12 +310,13 @@ function _time_filter(from, to, timeField) {
 }
 
 function init(config) {
-    DEFAULT_FETCH_SIZE = config.fetch_size || 10000;
+    DEFAULT_FETCH_SIZE = config.fetch_size || DEFAULT_FETCH_SIZE;
     DEFAULT_DEEP_PAGING_LIMIT = config.deep_paging_limit || 200000;
 }
 
 module.exports = {
     init: init,
+    DEFAULT_FETCH_SIZE: DEFAULT_FETCH_SIZE,
     fetcher: fetcher,
     aggregation_fetcher: aggregation_fetcher
 };

--- a/test/elastic-adapter-limits.js
+++ b/test/elastic-adapter-limits.js
@@ -62,13 +62,13 @@ describe('elastic source limits', function() {
                 });
             });
 
-            it('enforces tail across multiple fetches', function() {
-                var extra = '-fetch_size 2 | tail 4';
+            it('doesn\'t optimize tail in excess of fetch size', function() {
+                var extra = '-fetch_size 2 | tail 8';
                 return test_utils.read({id: type}, extra)
                 .then(function(result) {
-                    var expected = _.last(points, 4);
+                    var expected = _.last(points, 8);
                     test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
-                    expect(result.prog.graph.es_opts.limit).equal(4);
+                    expect(result.prog.graph.es_opts.limit).equal(undefined);
                 });
             });
 


### PR DESCRIPTION
If the tail limit exceeds the fetch size, then we don't get points
in the right order. Rather than add a bunch of complexity to keep
optimizing this edge case, let's just not optimize it.

@VladVega 