### PR TITLE
query: use ISO times, not millis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 
-cache:
-  directories:
-    - node_modules
-
 addons:
   apt:
     sources:

--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -208,7 +208,7 @@ function points_from_grouped_response(response, info) {
         if (fields.length === 0) {
             var new_points = bucket.buckets.map(function base_case(b) {
                 var pt = _aggregation_values(b, b.doc_count, info);
-                pt[field] = b.key;
+                pt[field] = b.key_as_string || b.key;
 
                 // Following Juttle 'reduce' behavior, we don't output points
                 // for an empty batch if the reducer has 'groupby'

--- a/lib/query.js
+++ b/lib/query.js
@@ -87,8 +87,7 @@ function fetcher(client, filter, query_start, query_end, options) {
     // if more than fetch_size events have the same timestamp, we do
     // a "bridge fetch" which pages through all the points with that timestamp
     function bridge_fetch() {
-        var bridge_date = new Date(last_seen_timestamp);
-        var bridge_time = new JuttleMoment({rawDate: bridge_date});
+        var bridge_time = new JuttleMoment(last_seen_timestamp);
 
         var time_filter = {term: {}};
         time_filter.term[timeField] = bridge_time.valueOf();
@@ -135,8 +134,7 @@ function fetcher(client, filter, query_start, query_end, options) {
             bridge_offset = 0;
             return bridge_fetch();
         } else {
-            var new_from_date = new Date(last_seen_timestamp);
-            query_start = new JuttleMoment({rawDate: new_from_date});
+            query_start = new JuttleMoment(last_seen_timestamp);
             if (!processed.eof) {
                 processed.points = filtered_points;
             }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,7 +16,7 @@ var CONFIG = {};
 function pointsFromESDocs(hits, timeField, idField) {
     return hits.map(function(hit) {
         var point = hit._source;
-        var time = new Date(point[timeField]).getTime();
+        var time = point[timeField];
         var newPoint = _.omit(point, timeField);
         newPoint.time = time;
 

--- a/test/elastic-adapter.spec.js
+++ b/test/elastic-adapter.spec.js
@@ -180,7 +180,7 @@ describe('elastic source', function() {
         });
 
         it('writes with -id "b", a broken endpoint', function() {
-            return test_utils.write([{}], {id: 'b'})
+            return test_utils.write([{time: new Date().toISOString()}], {id: 'b'})
             .then(function(result) {
                 expect(result.errors).deep.equal(['insertion failed: Failed to connect to Elasticsearch']);
             });


### PR DESCRIPTION
using millis made Jut 1.0 fly, but it's an unnecessary complication
now that doesn't play well with toNative's newfound view that all
numbers are seconds

Now that a version of Juttle with the "numbers are seconds" idea has been pushed, the adapter is giving weird times. Let's get this in and knock that off.

@demmer @VladVega @dmehra 