### PR TITLE
query: don't do an unnecessary bridge fetch

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -122,6 +122,9 @@ function fetcher(client, filter, query_start, query_end, options) {
     // are simultaneous. This makes sure the next query, which starts
     // at the last timestamp, won't return any duplicates
     function drop_last_time_stamp_and_maybe_bridge_fetch(processed) {
+        if (processed.eof) {
+            return processed;
+        }
         var last = _.last(processed.points);
         last_seen_timestamp = last && last.time;
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -122,9 +122,7 @@ function fetcher(client, filter, query_start, query_end, options) {
     // are simultaneous. This makes sure the next query, which starts
     // at the last timestamp, won't return any duplicates
     function drop_last_time_stamp_and_maybe_bridge_fetch(processed) {
-        if (processed.eof) {
-            return processed;
-        }
+        if (processed.eof) { return processed; }
         var last = _.last(processed.points);
         last_seen_timestamp = last && last.time;
 


### PR DESCRIPTION
If all the results come back in a single fetch, there's no need
to do an extra bridge.