### PR TITLE
optimizer: build date histograms with timeField

### DIFF
--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -101,11 +101,11 @@ function es_offset_from_duration(on) {
 // and -on arguments to batch or reduce.  subagg is a
 // dictionary of sub-aggregations to be run in each time bucket.
 // (the results of previous called to make_reducer_agg() )
-function make_datehist_agg(every, on, subagg) {
+function make_datehist_agg(every, on, time_field, subagg) {
     var interval = es_interval_from_duration(every);
     if (interval === null) { return null; }
     var histogram = {
-        field: 'time',
+        field: time_field,
         interval: interval,
         min_doc_count: 0
     };

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -33,6 +33,7 @@ function EventsInserter(client, options) {
     this.interval = options.interval;
     this.timeField = options.timeField;
     this.idField = options.idField;
+    this.warn = options.warn;
 }
 
 function get_and_undefine(pt, key) {
@@ -46,6 +47,12 @@ function get_and_undefine(pt, key) {
 EventsInserter.prototype.push = function(event) {
     validate_event(event);
     var ts = normalize_timestamp(get_and_undefine(event, 'time'));
+
+    if (event.hasOwnProperty(this.timeField)) {
+        var message = util.format('clobbering %s value of %s with %s', this.timeField, JSON.stringify(event), ts.toISOString());
+        this.warn(message);
+    }
+
     event[this.timeField] = ts.toISOString();
 
     var _id = get_and_undefine(event, this.idField);

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -35,15 +35,20 @@ function EventsInserter(client, options) {
     this.idField = options.idField;
 }
 
+function get_and_undefine(pt, key) {
+    if (!key) { return; }
+    var value = pt[key];
+    pt[key] = undefined;
+
+    return value;
+}
+
 EventsInserter.prototype.push = function(event) {
     validate_event(event);
-    var ts = normalize_timestamp(event.time);
+    var ts = normalize_timestamp(get_and_undefine(event, 'time'));
     event[this.timeField] = ts.toISOString();
-    var _id;
-    if (this.idField && event[this.idField]) {
-        _id = event[this.idField];
-        event[this.idField] = undefined;
-    }
+
+    var _id = get_and_undefine(event, this.idField);
 
     this.events.push({
         index: {

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -6,6 +6,7 @@ var aggregation = require('./aggregation');
 var logger = require('juttle/lib/logger').getLogger('elastic-optimize');
 var ALLOWED_REDUCE_OPTIONS = ['every', 'forget', 'groupby', 'on'];
 var DEFAULT_FETCH_SIZE = require('./query').DEFAULT_FETCH_SIZE;
+var utils = require('./utils');
 
 function _getFieldName(node) {
     return node.expression.value;
@@ -160,8 +161,9 @@ var optimizer = {
         if (graph.node_has_option(reduce, 'every')) {
             every = graph.node_get_option(reduce, 'every');
             on = graph.node_get_option(reduce, 'on');
+            var time_field = graph.node_get_option(read, 'timeField') || utils.DEFAULT_CONFIG.timeField;
 
-            aggrs = aggregation.make_datehist_agg(every, on, aggrs);
+            aggrs = aggregation.make_datehist_agg(every, on, time_field, aggrs);
 
             if (aggrs === null) { return false; }
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -107,4 +107,5 @@ module.exports = {
     pointsFromESDocs: pointsFromESDocs,
     default_config_property_for_id: default_config_property_for_id,
     ensure_valid_interval: ensure_valid_interval,
+    DEFAULT_CONFIG: DEFAULT_CONFIG,
 };

--- a/lib/write.js
+++ b/lib/write.js
@@ -19,6 +19,7 @@ var Write = Juttle.proc.sink.extend({
     process: function(points) {
         var self = this;
         var inserter_options = _.pick(this, 'id', 'index', 'type', 'interval', 'timeField', 'idField');
+        inserter_options.warn = this.warn.bind(this);
         var inserter = elastic.get_inserter(inserter_options);
         for (var i = 0; i < points.length; i++) {
             try {
@@ -43,6 +44,10 @@ var Write = Juttle.proc.sink.extend({
             self.in_progress_writes--;
             self._maybe_done();
         });
+    },
+
+    warn: function(message) {
+        this.trigger('warning', new Error(message));
     },
 
     _default_config: function(property) {

--- a/test/elastic-adapter.spec.js
+++ b/test/elastic-adapter.spec.js
@@ -178,7 +178,7 @@ describe('elastic source', function() {
                             return test_utils.verify_import(my_timed_point, type, '*', {timeField: 'my_time'});
                         })
                         .then(function() {
-                            return test_utils.search(type);
+                            return test_utils.search(type, test_utils.test_id);
                         })
                         .then(function(es_result) {
                             var sources = _.pluck(es_result.hits.hits, '_source');
@@ -206,6 +206,16 @@ describe('elastic source', function() {
                     return test_utils.read(options, extra)
                         .then(function(result) {
                             expect(result.sinks.table).deep.equal([{time: end, count: 1}]);
+                        });
+                });
+
+                it('warns if you clobber a timeField field', function() {
+                    return test_utils.write(my_timed_point, {timeField: 'name', id: type})
+                        .then(function(result) {
+                            var message = util.format('clobbering name value of {"name":"my_time_test"} with %s', time);
+                            expect(result.warnings).deep.equal([message]);
+                            var expected_point = {name: time};
+                            return test_utils.verify_import([expected_point], type, '*', {timeField: 'my_time'});
                         });
                 });
             });

--- a/test/elastic-test-utils.js
+++ b/test/elastic-test-utils.js
@@ -246,11 +246,11 @@ function list_indices() {
         });
 }
 
-function search(type) {
+function search(type, index) {
     var client = type === 'aws' ? aws_client : local_client;
 
     return client.searchAsync({
-        index: '*',
+        index: index || '*',
         type: '',
         size: 10000,
         body: {}

--- a/test/elastic-test-utils.js
+++ b/test/elastic-test-utils.js
@@ -140,7 +140,8 @@ function clear_data(type, indexes) {
     }
 }
 
-function verify_import(points, type, indexes) {
+function verify_import(points, type, indexes, options) {
+    options = options || {};
     var client = type === 'aws' ? aws_client : local_client;
     var request_body = {
         index: indexes || TEST_RUN_ID + '*',
@@ -149,6 +150,16 @@ function verify_import(points, type, indexes) {
             size: 10000
         }
     };
+
+    if (options.timeField !== 'time') {
+        points = points.map(function(pt) {
+            var timeField = options.timeField || '@timestamp';
+            pt = _.clone(pt);
+            pt[timeField] = pt.time;
+            delete pt.time;
+            return pt;
+        });
+    }
 
     return retry(function() {
         return client.searchAsync(request_body)
@@ -235,10 +246,21 @@ function list_indices() {
         });
 }
 
-function search() {
-    return local_client.search({
+function search(type) {
+    var client = type === 'aws' ? aws_client : local_client;
+
+    return client.searchAsync({
         index: '*',
-        size: 10000
+        type: '',
+        size: 10000,
+        body: {}
+    })
+    .then(function(result) {
+        if (Array.isArray(result)) {
+            result = result[0];
+        }
+
+        return result;
     });
 }
 


### PR DESCRIPTION
The date histogram builder assumes that the time field is always 'time'.
That's not right. It should use the timeField parameter.

This defeated our tests because we always write points with a "time" field
as well as the timeField, so date histograms on the "time" field work
even though it's not the timeField. Let's drop the "time" field from points
with a timeField on write.

fixes https://github.com/juttle/juttle-elastic-adapter/issues/66

@demmer @VladVega @dmehra 