### PR TITLE
Do not call JuttleMoment.duration with "new"

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -184,12 +184,12 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
     var indices = options.indices;
     var type = options.type;
     var aggregations = options.aggregations;
-    var reduce_every = aggregations.reduce_every ? new JuttleMoment.duration(aggregations.reduce_every) : null;
+    var reduce_every = aggregations.reduce_every ? JuttleMoment.duration(aggregations.reduce_every) : null;
     var timeField = options.timeField;
 
     function get_batch_offset_as_duration(every_duration) {
         try {
-            return new JuttleMoment.duration(aggregations.reduce_on);
+            return JuttleMoment.duration(aggregations.reduce_on);
         } catch(err) {
             // translate a non-duration -on into the equivalent duration
             // e.g. if we're doing -every :hour: -on :2015-03-16T18:32:00.000Z:


### PR DESCRIPTION
`JuttleMoment.duration` is not a constructor (just a factory function), so it should not be called using the `new` operator. This PR removes `new` from any such calls.