### PR TITLE
Indicate AWS backends with {aws: true}

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ and `port` in this configuration.
 
 The value for `elastic` can also be an array of Elasticsearch host locations. Give each one a unique `id` field, and `read -id` and `write -id` will use the appropriate host.
 
-The Juttle Elastic Adapter can also make requests to Amazon Elasticsearch Service instances, which requires a little more configuration. To connect to Amazon Elasticsearch Service, an entry in the adapter config must have `{"type": "aws"}` as well as `region`, `endpoint`, `access_key`, and `secret_key` fields. `access_key` and `secret_key` can also be specified by the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` respectively.
+The Juttle Elastic Adapter can also make requests to Amazon Elasticsearch Service instances, which requires a little more configuration. To connect to Amazon Elasticsearch Service, an entry in the adapter config must have `{"aws": true}` as well as `region`, `endpoint`, `access_key`, and `secret_key` fields. `access_key` and `secret_key` can also be specified by the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` respectively.
 
 Here's an example Juttle Elastic Adapter configuration that can connect to a local Elasticsearch instance running on port 9200 using `read/write elastic -id "local"` and an Amazon Elasticsearch Service at `search-foo-bar.us-west-2.es.amazonaws.com` using `read/write elastic -id "amazon"`:
 
@@ -76,7 +76,7 @@ Here's an example Juttle Elastic Adapter configuration that can connect to a loc
             },
             {
                 "id": "amazon",
-                "type": "aws",
+                "aws": true,
                 "endpoint": "search-foo-bar.us-west-2.es.amazonaws.com",
                 "region": "us-west-2",
                 "access_key": "(my access key ID)",

--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -25,7 +25,7 @@ function init(config) {
 
     clients = config.map(function(entry) {
         var client;
-        if (entry.type === 'aws') {
+        if (entry.aws) {
             if (!entry.region || !entry.endpoint) {
                 throw new Error('AWS expects region and endpoint');
             }

--- a/test/elastic-test-utils.js
+++ b/test/elastic-test-utils.js
@@ -37,6 +37,7 @@ var local_client = Promise.promisifyAll(new Elasticsearch.Client({
 var test_index = 'my_index';
 var has_index_id = 'has_default_index';
 var has_default_type_id = 'has_default_type';
+var aws_has_default_type_id = 'aws_has_default_type';
 
 var config = [{
     id: LOCAL,
@@ -74,7 +75,15 @@ if (_.contains(modes, AWS)) {
 
     config.push({
         id: AWS,
-        type: 'aws',
+        aws: true,
+        endpoint: AWS_HOST,
+        region: AWS_REGION
+    });
+
+    config.push({
+        id: aws_has_default_type_id,
+        aws: true,
+        type: 'aws_default_type',
         endpoint: AWS_HOST,
         region: AWS_REGION
     });
@@ -326,6 +335,7 @@ module.exports = {
     test_index: test_index,
     has_index_id: has_index_id,
     has_default_type: has_default_type_id,
+    aws_has_default_type_id: aws_has_default_type_id,
     test_id: TEST_RUN_ID,
     search: search,
     list_types: list_types,


### PR DESCRIPTION
The current paradigm, {type: 'aws'}, conflicts with the -type option
to read/write, so we can't do that.

Fixes https://github.com/juttle/juttle-elastic-adapter/issues/67

@demmer @VladVega 