### PR TITLE
write: speed up small batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Name | Type | Required | Description | Default
 `type` | string | no | document type to write to | `event`
 `timeField` | string | no | field containing timestamps | `@timestamp`
 `idField` | string | no | if specified, the value of this field on each point will be used as the document ID for the corresponding Elasticsearch document and not stored | none
+`chunkSize` | number | no | buffer points until `chunkSize` have been received or the program ends, then flush | 1024
+`concurrency` | number | no | number of concurrent bulk requests to make to Elasticsearch (each inserts `<= chunkSize` points) | 10
 
 ### Optimizations
 
@@ -149,7 +151,7 @@ This program will form an ES query that asks it do count the documents in `scrat
 _Less optimized example_
 
 ```juttle
-read elastic -last :1 hour: name = 'test' 
+read elastic -last :1 hour: name = 'test'
 | put threshold = 42
 | filter value > threshold
 ```

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -69,7 +69,7 @@ EventsInserter.prototype.push = function(event) {
 
 EventsInserter.prototype.end = function() {
     var errors = [];
-    logger.debug('inserter.end(), points:', JSON.stringify(this.points));
+    logger.debug('inserter.end(), points:', this.events.length);
     if (this.events.length === 0) {
         return Promise.resolve(errors);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,7 +9,7 @@ var DEFAULT_CONFIG = {
     idField: undefined,
     id: undefined,
     concurrency: 10,
-    chunkSize: 1000,
+    chunkSize: 1024,
     writeType: 'event',
     readType: ''
 };

--- a/lib/write.js
+++ b/lib/write.js
@@ -6,7 +6,7 @@ var elastic = require('./elastic');
 var utils = require('./utils');
 var util = require('util');
 var AdapterWrite = require('juttle/lib/runtime/adapter-write');
-var Promise = require('bluebird');
+var ConcurrencyMaster = require('concurrency-master');
 var logger = require('juttle/lib/logger').getLogger('elastic-write');
 
 class WriteElastic extends AdapterWrite {
@@ -16,7 +16,10 @@ class WriteElastic extends AdapterWrite {
         this._set_or_default('id', 'timeField', 'idField', 'concurrency', 'chunkSize');
         this.type = options.type || this._default_config('writeType');
         this._setup_index(options);
-        this.write_promise = Promise.resolve();
+        this.points = [];
+        this.concurrency_master = new ConcurrencyMaster(this.concurrency);
+
+        this.chunks_written = 0; // for tests
     }
 
     _set_or_default() {
@@ -26,29 +29,20 @@ class WriteElastic extends AdapterWrite {
         }
     }
 
-    write(points) {
-        this.write_promise = this.write_promise.then(() => {
-            return Promise.map(_.range(points.length / this.chunkSize), (n) => {
-                var chunk = points.splice(0, this.chunkSize);
+    write(pts) {
+        this.points = this.points.concat(pts);
+        if (this.points.length >= this.chunkSize) {
+            while (this.points.length > 0) {
+                var chunk = this.points.splice(0, this.chunkSize);
 
-                return this._write(chunk)
-                .then((errors) => {
-                    errors.forEach((err) => {
-                        var message = 'point rejected by Elasticsearch due to: ' + err;
-                        logger.debug(message);
-                        this.trigger('error', new Error(message));
-                    });
-                })
-                .catch((err) => {
-                    logger.debug('error during insert', err.stack || err);
-                    var message = err.message === 'No Living connections' ? 'Failed to connect to Elasticsearch' : err.message;
-                    this.trigger('error', new Error('insertion failed: ' + message));
-                });
-            }, {concurrency: this.concurrency});
-        });
+                this._write(chunk);
+            }
+        }
     }
 
     _write(chunk) {
+        var self = this;
+        this.chunks_written++;
         var inserter_options = _.pick(this, 'id', 'index', 'type', 'interval', 'timeField', 'idField');
         inserter_options.warn = this.warn.bind(this);
         var inserter = elastic.get_inserter(inserter_options);
@@ -63,7 +57,22 @@ class WriteElastic extends AdapterWrite {
             }
         }
 
-        return inserter.end();
+        var execute_write = function() {
+            return inserter.end().then((errors) => {
+                errors.forEach((err) => {
+                    var message = 'point rejected by Elasticsearch due to: ' + err;
+                    logger.debug(message);
+                    self.trigger('error', new Error(message));
+                });
+            })
+            .catch((err) => {
+                logger.debug('error during insert', err.stack || err);
+                var message = err.message === 'No Living connections' ? 'Failed to connect to Elasticsearch' : err.message;
+                self.trigger('error', new Error('insertion failed: ' + message));
+            });
+        };
+
+        this.concurrency_master.add(execute_write);
     }
 
     warn(message) {
@@ -99,7 +108,11 @@ class WriteElastic extends AdapterWrite {
     }
 
     eof() {
-        return this.write_promise;
+        if (this.points.length > 0) {
+            this._write(this.points);
+        }
+
+        return this.concurrency_master.wait();
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "aws-es": "juttle/aws-es.git",
     "bluebird": "^2.9.30",
     "bluebird-retry": "^0.5.2",
+    "concurrency-master": "^0.1.0",
     "current-week-number": "^1.0.7",
     "elasticsearch": "^10.0.1",
     "extendable-base": "^0.3.1",

--- a/test/elastic-adapter.spec.js
+++ b/test/elastic-adapter.spec.js
@@ -418,42 +418,6 @@ describe('elastic source', function() {
         });
     });
 
-    describe('write edge cases', function() {
-        after(function() {
-            return test_utils.clear_data();
-        });
-
-        it('writes a nested object', function() {
-            var nested_object = {
-                time: new Date().toISOString(),
-                nest: {nested_key: 'nest'},
-                name: 'nest_haver'
-            };
-            return test_utils.write([nested_object])
-                .then(function(result) {
-                    expect(result.errors).deep.equal([]);
-                    return retry(function() {
-                        return test_utils.search()
-                            .then(function(result) {
-                                var hits = _.pluck(result.hits.hits, '_source');
-                                var imported = _.findWhere(hits, {name: 'nest_haver'});
-
-                                expect(imported).exist;
-                                expect(imported.nest).deep.equal(nested_object.nest);
-                            });
-                    });
-                });
-        });
-
-        it('fails to write a point with an _id field', function() {
-            var _id_point = {time: new Date().toISOString(), _id: 'this is broken now'};
-            return test_utils.write([_id_point])
-                .then(function(result) {
-                    expect(result.errors).match(/point rejected by Elasticsearch/);
-                });
-        });
-    });
-
     describe('idField', function() {
         var time = new Date().toISOString();
         var id_point = {time: time, name: 'id_test', id_field: 'my_id', value: 10};

--- a/test/write.spec.js
+++ b/test/write.spec.js
@@ -1,0 +1,58 @@
+var _ = require('underscore');
+var retry = require('bluebird-retry');
+var expect = require('chai').expect;
+
+var test_utils = require('./elastic-test-utils');
+
+var modes = test_utils.modes;
+
+describe('write', function() {
+    this.timeout(300000);
+    modes.forEach(function(type) {
+        describe(type, function() {
+            afterEach(function() {
+                return test_utils.clear_data(type);
+            });
+
+            it('fails to write a point with an _id field', function() {
+                var _id_point = {time: new Date().toISOString(), _id: 'this is broken now'};
+                return test_utils.write([_id_point], {id: type})
+                    .then(function(result) {
+                        expect(result.errors).match(/point rejected by Elasticsearch/);
+                    });
+            });
+
+            it('writes a nested object', function() {
+                var nested_object = {
+                    time: new Date().toISOString(),
+                    nest: {nested_key: 'nest'},
+                    name: 'nest_haver'
+                };
+                return test_utils.write([nested_object], {id: type})
+                    .then(function(result) {
+                        expect(result.errors).deep.equal([]);
+                        return retry(function() {
+                            return test_utils.search(type)
+                                .then(function(result) {
+                                    var hits = _.pluck(result.hits.hits, '_source');
+                                    var imported = _.findWhere(hits, {name: 'nest_haver'});
+                                    expect(imported).exist;
+                                    expect(imported.nest).deep.equal(nested_object.nest);
+                                });
+                        });
+                    });
+            });
+
+            it('writes with -chunkSize', function() {
+                var chunkSize = 5;
+                var points = test_utils.generate_sample_data({count: 100});
+                return test_utils.write(points, {id: type, chunkSize: chunkSize})
+                    .then(function(result) {
+                        var write = result.prog.graph.out_.default[0].proc.adapter;
+                        expect(write.chunks_written).equal(points.length / chunkSize);
+                        return test_utils.verify_import(points, type);
+                    });
+            });
+        });
+    });
+});


### PR DESCRIPTION
instead of making a sequential request for each call to write()
buffer until we get chunkSize and flush at that time

use the new ConcurrencyMaster to make sure the specified
concurrency is respected

Fixes https://github.com/juttle/juttle-elastic-adapter/issues/77

@demmer @VladVega 