### PR TITLE
update to new Juttle API

### DIFF
--- a/lib/filter-es-compiler.js
+++ b/lib/filter-es-compiler.js
@@ -3,7 +3,7 @@
 // The filter is returned in the "filter" property of the toplevel AST node.
 
 var ASTVisitor = require('juttle/lib/compiler/ast-visitor');
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var JuttleMoment = require('juttle/lib/runtime/types/juttle-moment');
 
 var OPS_TO_INVERTED_OPS = {
     '==': '==',

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -1,7 +1,7 @@
 var util = require('util');
 var Promise = require('bluebird');
 
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var JuttleMoment = require('juttle/lib/runtime/types/juttle-moment');
 var utils = require('./utils');
 var logger = require('juttle/lib/logger').getLogger('elastic-insert');
 

--- a/lib/query-common.js
+++ b/lib/query-common.js
@@ -2,7 +2,7 @@ var Promise = require('bluebird');
 var request = Promise.promisifyAll(require('request'));
 request.async = Promise.promisify(request);
 
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var JuttleMoment = require('juttle/lib/runtime/types/juttle-moment');
 var errors = require('./es-errors');
 var utils = require('./utils');
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,7 +1,7 @@
 var Promise = require('bluebird');
 var _ = require('underscore');
 
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var JuttleMoment = require('juttle/lib/runtime/types/juttle-moment');
 var common = require('./query-common');
 var juttle_utils = require('juttle/lib/runtime').utils;
 var utils = require('./utils');

--- a/lib/read.js
+++ b/lib/read.js
@@ -8,7 +8,7 @@ var elastic = require('./elastic');
 var utils = require('./utils');
 var common = require('./query-common');
 var AdapterRead = require('juttle/lib/runtime/adapter-read');
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var JuttleMoment = require('juttle/lib/runtime/types/juttle-moment');
 
 class ReadElastic extends AdapterRead {
     constructor(options, params) {
@@ -48,6 +48,12 @@ class ReadElastic extends AdapterRead {
         }
 
         this.executed_queries = [];
+    }
+
+    static allowedOptions() {
+        var elastic_options = ['id', 'timeField', 'type', 'idField', 'fetch_size',
+            'es_opts', 'deep_paging_limit', 'index', 'interval', 'optimize', 'indexInterval'];
+        return AdapterRead.commonOptions.concat(elastic_options);
     }
 
     periodicLiveRead() {

--- a/lib/write.js
+++ b/lib/write.js
@@ -19,6 +19,11 @@ class WriteElastic extends AdapterWrite {
         this.write_promise = Promise.resolve();
     }
 
+    allowedOptions() {
+        return ['type', 'index', 'interval', 'id', 'timeField', 'idField',
+            'concurrency', 'chunkSize'];
+    }
+
     _set_or_default() {
         for (var i = 0; i < arguments.length; i++) {
             var property = arguments[i];

--- a/test/optimization.spec.js
+++ b/test/optimization.spec.js
@@ -178,7 +178,7 @@ describe('optimization', function() {
                     return test_utils.read({id: type}, '| reduce count()')
                     .then(function(result) {
                         var first_node = result.prog.graph.head[0];
-                        expect(first_node.procName).equal('read');
+                        expect(first_node.procName).equal('read elastic');
 
                         var second_node = first_node.out_.default[0].proc;
                         expect(second_node.procName).equal('view');


### PR DESCRIPTION
juttle/lib/moment is gone, and read/write have allowedOptions lists
fixes https://github.com/juttle/juttle-elastic-adapter/issues/74

When the next Juttle release comes out, I'll update the dependency and we can merge this.
@demmer @VladVega 