### PR TITLE
read: warn on invalid options

### DIFF
--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -7,9 +7,10 @@ var Inserter = require('./insert');
 var query = require('./query');
 var aggregation = require('./aggregation');
 var utils = require('./utils');
+
 var logger = require('juttle/lib/logger').getLogger('elastic');
 
-var clients;
+var instances;
 
 function init(config) {
     logger.debug('initializing:', JSON.stringify(config));
@@ -19,7 +20,7 @@ function init(config) {
 
     utils.init(config);
 
-    clients = config.map(function(entry) {
+    instances = config.map(function(entry) {
         var client;
         if (entry.aws) {
             client = new AmazonElasticsearchClient({
@@ -67,17 +68,20 @@ function validate_config(config) {
     });
 }
 
-function _client_for_id(id) {
-    if (id === undefined) {
-        return clients[0].client;
-    } else {
-        var endpoint = _.findWhere(clients, {id: id});
-        if (!endpoint) {
-            throw new Error('invalid id: ' + id);
-        }
+function _instance_for_id(id) {
+    if (id === undefined) { return instances[0]; }
 
-        return endpoint.client;
+    var instance = _.findWhere(instances, {id: id});
+    if (!instance) {
+        throw new Error('invalid id: ' + id);
     }
+
+    return instance;
+}
+
+function _client_for_id(id) {
+    var instance = _instance_for_id(id);
+    return instance.client;
 }
 
 function get_inserter(options) {
@@ -94,9 +98,28 @@ function fetcher(id, filter, query_start, query_end, options) {
     }
 }
 
+function mapping_for_id(id, index, type) {
+    var instance = _instance_for_id(id);
+    return _get_mapping(instance.client, index, type)
+        .catch(function(err) {
+            logger.warn('error getting ES mapping', err);
+            return {};
+        });
+}
+
+function _get_mapping(client, index, type) {
+    var options = {index: index || '*', type: type || ''};
+    if (client instanceof AmazonElasticsearchClient) {
+        return client.getMappingAsync(options);
+    } else {
+        return client.indices.getMapping(options);
+    }
+}
+
 module.exports = {
     init: init,
     validate_config: validate_config,
     get_inserter: get_inserter,
+    mapping_for_id: mapping_for_id,
     fetcher: fetcher
 };

--- a/lib/filter-es-compiler.js
+++ b/lib/filter-es-compiler.js
@@ -27,10 +27,13 @@ var FilterESCompiler = ASTVisitor.extend({
     initialize: function(options) {
         options = options || {};
         this.skipField = options.skipField;
+        this.filtered_fields = [];
     },
 
     compile: function(node) {
-        return this.visit(node);
+        var result = this.visit(node);
+        result.filtered_fields = this.filtered_fields;
+        return result;
     },
 
     visitNullLiteral: function(node) {
@@ -85,6 +88,7 @@ var FilterESCompiler = ASTVisitor.extend({
                 };
 
             case '*':
+                this.filtered_fields.push(node.value);
                 return this.visit(node.expression);
 
             default:

--- a/lib/read.js
+++ b/lib/read.js
@@ -19,11 +19,13 @@ class ReadElastic extends AdapterRead {
         this.idField = options.idField || this._default_config('idField');
 
         this._setup_index(options);
+        this.filtered_fields = [];
         var filter_ast = params.filter_ast;
         if (filter_ast) {
             var filter_es_compiler = new FilterESCompiler();
             var result = filter_es_compiler.compile(filter_ast);
             this.es_filter = result.filter;
+            this.filtered_fields = result.filtered_fields;
         }
 
         var optimization_info = params && params.optimization_info || {};
@@ -65,6 +67,50 @@ class ReadElastic extends AdapterRead {
         return utils.default_config_property_for_id(this.id, property);
     }
 
+    _check_options_vs_mapping() {
+        if (this.checked_options_vs_mapping_already) { return Promise.resolve(); }
+        this.checked_options_vs_mapping_already = true;
+
+        return elastic.mapping_for_id(this.id, this.index, this.type)
+            .then((mapping) => {
+                _.each(mapping, (mapping_object, index) => {
+                    var index_mapping = mapping_object.mappings || {};
+                    _.each(index_mapping, (props_object, type) => {
+                        var properties = props_object.properties;
+                        this._warn_if_missing(properties, this.timeField, index, type);
+
+                        this.filtered_fields.forEach((field) => {
+                            this._warn_if_analyzed(properties, field, index, type);
+                            this._warn_if_missing(properties, field, index, type);
+                        });
+
+                        var reduce_by_fields = (this.es_opts.aggregations &&
+                            this.es_opts.aggregations.grouping) || [];
+                        reduce_by_fields.forEach((field) => {
+                            this._warn_if_analyzed(properties, field, index, type);
+                            this._warn_if_missing(properties, field, index, type);
+                        });
+                    });
+                });
+            });
+    }
+
+    _warn_if_analyzed(properties, field, index, type) {
+        if (properties && properties.hasOwnProperty(field)) {
+            if (properties[field].index !== 'not_analyzed') {
+                this.warn(`field "${field}" is analyzed in type "${type}" in index ` +
+                    `"${index}", results may be unexpected`);
+            }
+        }
+    }
+
+    _warn_if_missing(properties, field, index, type) {
+        if (properties && !properties.hasOwnProperty(field)) {
+            this.warn(`index "${index}" has no known property ` +
+                `"${field}" for type "${type}"`);
+        }
+    }
+
     _setup_index(options) {
         this.index = options.index || this._default_config('readIndex');
         this.interval = options.indexInterval || this._default_config('indexInterval');
@@ -91,14 +137,21 @@ class ReadElastic extends AdapterRead {
         return limit;
     }
 
-    read(from, to, limit, state) {
-        this.es_opts.indices = common.get_indices(from, to, this.index, this.interval);
-        this.es_opts.limit = this._calculate_limit(limit);
-        if (!this.fetcher) {
-            this.fetcher = elastic.fetcher(this.id, this.es_filter, from, to, this.es_opts);
-        }
+    warn(message) {
+        this.trigger('warning', new Error(message));
+    }
 
-        return this.fetcher()
+    read(from, to, limit, state) {
+        return this._check_options_vs_mapping()
+            .then(() => {
+                this.es_opts.indices = common.get_indices(from, to, this.index, this.interval);
+                this.es_opts.limit = this._calculate_limit(limit);
+                if (!this.fetcher) {
+                    this.fetcher = elastic.fetcher(this.id, this.es_filter, from, to, this.es_opts);
+                }
+
+                return this.fetcher();
+            })
             .then((result) => {
                 this._stash_executed_query(result);
                 this.fetcher = result.eof ? null : this.fetcher;


### PR DESCRIPTION
Check the ES mapping each read and use that knowledge to trigger a warning if a program uses an unknown `timeField` or filters on or reduces by an analyzed or unknown field. 

@demmer @VladVega 