### PR TITLE
Duration

### DIFF
--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -11,6 +11,7 @@ var logger = require('juttle/lib/logger').getLogger('elastic');
 
 var instances;
 var already_created_indices = {};
+var index_creation_promises = {};
 var DYNAMIC_MAPPING_SETTINGS = require('./dynamic-mapping-settings');
 
 function init(config) {
@@ -40,6 +41,8 @@ function init(config) {
         }
 
         Promise.promisifyAll(client);
+        // XXX https://github.com/juttle/juttle-elastic-adapter/issues/96
+        Promise.promisifyAll(client.indices || {});
 
         return {
             client: client,
@@ -118,7 +121,12 @@ function create_index_if_not_exists_with_type(client, index, type) {
     return _check_index_exists(client, index)
         .then((exists) => {
             if (!exists) {
-                return _create_index(client, index, type);
+                // limit to 1 concurrent creation request
+                index_creation_promises[index] = index_creation_promises[index] ||
+                    _create_index(client, index, type).finally(function() {
+                        index_creation_promises[index] = null;
+                    });
+                return index_creation_promises[index];
             }
         })
         .then(() => {
@@ -146,7 +154,7 @@ function _create_index(client, index, type) {
     if (client instanceof AmazonElasticsearchClient) {
         return client.createIndexAsync(options);
     } else {
-        return client.indices.create(options);
+        return client.indices.createAsync(options);
     }
 }
 

--- a/lib/filter-es-compiler.js
+++ b/lib/filter-es-compiler.js
@@ -65,7 +65,7 @@ var FilterESCompiler = ASTVisitor.extend({
     },
 
     visitDurationLiteral: function(node) {
-        return JuttleMoment.duration(node.value).seconds();
+        return JuttleMoment.duration(node.value).toJSON();
     },
 
     visitFilterLiteral: function(node) {

--- a/test/write.spec.js
+++ b/test/write.spec.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var retry = require('bluebird-retry');
 var expect = require('chai').expect;
 
+var elastic = require('../lib/elastic');
 var test_utils = require('./elastic-test-utils');
 var juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
 var check_juttle = juttle_test_utils.check_juttle;
@@ -12,6 +13,7 @@ describe('write', function() {
     modes.forEach(function(type) {
         describe(type, function() {
             afterEach(function() {
+                elastic.clear_already_created_indices();
                 return test_utils.clear_data(type);
             });
 
@@ -76,7 +78,7 @@ describe('write', function() {
                 });
             });
 
-            it('writes a point with a duration', function() { // pending https://github.com/juttle/juttle-elastic-adapter/pull/91
+            it('writes a point with a duration', function() {
                 var time = '5 minutes';
                 var write_program = `emit -limit 1 | put duration = :${time}:` +
                     ` | write elastic -id "${type}" -index "${test_utils.test_id}"`;

--- a/test/write.spec.js
+++ b/test/write.spec.js
@@ -3,6 +3,8 @@ var retry = require('bluebird-retry');
 var expect = require('chai').expect;
 
 var test_utils = require('./elastic-test-utils');
+var juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
+var check_juttle = juttle_test_utils.check_juttle;
 
 var modes = test_utils.modes;
 
@@ -47,10 +49,59 @@ describe('write', function() {
                 var points = test_utils.generate_sample_data({count: 100});
                 return test_utils.write(points, {id: type, chunkSize: chunkSize})
                     .then(function(result) {
+                        expect(result.errors).deep.equal([]);
                         var write = result.prog.graph.out_.default[0].proc.adapter;
                         expect(write.chunks_written).equal(points.length / chunkSize);
                         return test_utils.verify_import(points, type);
                     });
+            });
+
+            it('writes a point with a moment', function() {
+                var time = new Date().toISOString();
+                var write_program = `emit -limit 1 | put fake_time = :${time}:` +
+                    ` | write elastic -id "${type}" -index "${test_utils.test_id}"`;
+
+                return check_juttle({
+                    program: write_program
+                })
+                .then(function(result) {
+                    expect(result.errors).deep.equal([]);
+                    return retry(function() {
+                        return test_utils.read({id: type}, `fake_time = :${time}:`)
+                            .then(function(result) {
+                                expect(result.sinks.table[0].fake_time).equal(time);
+                            });
+
+                    });
+                });
+            });
+
+            it('writes a point with a duration', function() { // pending https://github.com/juttle/juttle-elastic-adapter/pull/91
+                var time = '5 minutes';
+                var write_program = `emit -limit 1 | put duration = :${time}:` +
+                    ` | write elastic -id "${type}" -index "${test_utils.test_id}"`;
+
+                return check_juttle({
+                    program: write_program
+                })
+                .then(function(result) {
+                    expect(result.errors).deep.equal([]);
+                    return retry(function() {
+                        return test_utils.read({id: type})
+                            .then(function(result) {
+                                expect(result.sinks.table.length).equal(1);
+                                expect(result.sinks.table[0].duration).equal('00:05:00.000');
+                            });
+                    });
+                })
+                .then(function() {
+                    return test_utils.read({id: type}, `duration = :${time}:`);
+                })
+                .then(function(result) {
+                    expect(result.warnings).deep.equal([]);
+                    expect(result.sinks.table.length).equal(1);
+                    expect(result.sinks.table[0].duration).equal('00:05:00.000');
+                });
             });
         });
     });


### PR DESCRIPTION
Add more moment/duration tests. Along the way, I found if points come in while an index is being created, we send another index creation request, causing one of them to fail with index already exists. Limit to one create-index request for a given index.

@dmehra @VladVega 