### PR TITLE
Update to new Juttle API

### DIFF
--- a/lib/filter-es-compiler.js
+++ b/lib/filter-es-compiler.js
@@ -3,7 +3,7 @@
 // The filter is returned in the "filter" property of the toplevel AST node.
 
 var ASTVisitor = require('juttle/lib/compiler/ast-visitor');
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var JuttleMoment = require('juttle/lib/runtime/types/juttle-moment');
 
 var OPS_TO_INVERTED_OPS = {
     '==': '==',

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -1,7 +1,7 @@
 var util = require('util');
 var Promise = require('bluebird');
 
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var JuttleMoment = require('juttle/lib/runtime/types/juttle-moment');
 var utils = require('./utils');
 var elastic = require('./elastic');
 var logger = require('juttle/lib/logger').getLogger('elastic-insert');

--- a/lib/query-common.js
+++ b/lib/query-common.js
@@ -1,4 +1,4 @@
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var JuttleMoment = require('juttle/lib/runtime/types/juttle-moment');
 var current_week_number = require('current-week-number');
 
 var errors = require('./es-errors');

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,7 +1,7 @@
 var Promise = require('bluebird');
 var _ = require('underscore');
 
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var JuttleMoment = require('juttle/lib/runtime/types/juttle-moment');
 var common = require('./query-common');
 var juttle_utils = require('juttle/lib/runtime').utils;
 var utils = require('./utils');

--- a/lib/read.js
+++ b/lib/read.js
@@ -8,7 +8,7 @@ var elastic = require('./elastic');
 var utils = require('./utils');
 var common = require('./query-common');
 var AdapterRead = require('juttle/lib/runtime/adapter-read');
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var JuttleMoment = require('juttle/lib/runtime/types/juttle-moment');
 
 class ReadElastic extends AdapterRead {
     constructor(options, params) {
@@ -51,6 +51,12 @@ class ReadElastic extends AdapterRead {
         }
 
         this.executed_queries = [];
+    }
+
+    static allowedOptions() {
+        var elastic_options = ['id', 'timeField', 'type', 'idField', 'fetch_size',
+            'es_opts', 'deep_paging_limit', 'index', 'interval', 'optimize', 'indexInterval'];
+        return AdapterRead.commonOptions.concat(elastic_options);
     }
 
     _validate_options(options) {

--- a/lib/write.js
+++ b/lib/write.js
@@ -23,6 +23,11 @@ class WriteElastic extends AdapterWrite {
         this.chunks_written = 0; // for tests
     }
 
+    allowedOptions() {
+        return ['type', 'index', 'interval', 'id', 'timeField', 'idField',
+            'concurrency', 'chunkSize'];
+    }
+
     _set_or_default() {
         for (var i = 0; i < arguments.length; i++) {
             var property = arguments[i];

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "underscore": "^1.8.3"
   },
   "peerDependencies": {
-    "juttle": ">=0.3.0"
+    "juttle": ">=0.4.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
juttle/lib/moment is gone, and read/write have allowedOptions lists
fixes #74
replaces https://github.com/juttle/juttle-elastic-adapter/pull/80, though it turns out this API still isn't released yet.