### PR TITLE
Use AWS client's .indices

### DIFF
--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -108,11 +108,10 @@ function mapping_for_id(id, index, type) {
 
 function _get_mapping(client, index, type) {
     var options = {index: index || '*', type: type || ''};
-    if (client instanceof AmazonElasticsearchClient) {
-        return client.getMappingAsync(options);
-    } else {
-        return client.indices.getMapping(options);
-    }
+    return client.indices.getMappingAsync(options)
+        .spread((response, statusCode) => {
+            return response;
+        });
 }
 
 function create_index_if_not_exists_with_type(client, index, type) {
@@ -136,11 +135,10 @@ function create_index_if_not_exists_with_type(client, index, type) {
 
 function _check_index_exists(client, index) {
     var options = {index: index};
-    if (client instanceof AmazonElasticsearchClient) {
-        return client.indexExistsAsync(options);
-    } else {
-        return client.indices.exists(options);
-    }
+    return client.indices.existsAsync(options)
+        .spread((exists, statusCode) => {
+            return exists;
+        });
 }
 
 function _create_index(client, index, type) {
@@ -151,11 +149,7 @@ function _create_index(client, index, type) {
         }
     };
     options.body.mappings[type] = DYNAMIC_MAPPING_SETTINGS;
-    if (client instanceof AmazonElasticsearchClient) {
-        return client.createIndexAsync(options);
-    } else {
-        return client.indices.createAsync(options);
-    }
+    return client.indices.createAsync(options);
 }
 
 // for tests


### PR DESCRIPTION
The AWS client now has the same API as the official ES client for
the functions it supports, so we don't need these instanceof checks

Fixes https://github.com/juttle/juttle-elastic-adapter/issues/96

@VladVega 