### PR TITLE
tests: rename type -> mode

### DIFF
--- a/test/live.spec.js
+++ b/test/live.spec.js
@@ -15,10 +15,10 @@ function generate_live_data() {
 }
 
 describe('elastic source', function() {
-    modes.forEach(function(type) {
-        describe('live reads -- ' + type, function() {
+    modes.forEach(function(mode) {
+        describe('live reads -- ' + mode, function() {
             afterEach(function() {
-                return test_utils.clear_data(type);
+                return test_utils.clear_data(mode);
             });
 
             function test_live(points_to_write, points_to_expect, extra) {
@@ -26,7 +26,7 @@ describe('elastic source', function() {
                 extra = extra || '';
                 var last_time = new Date(_.last(points_to_write).time).getTime();
                 var deactivateAfter = last_time - Date.now() + 5000;
-                var options = {id: type, from: 0, to: 'end', lag: '2s'};
+                var options = {id: mode, from: 0, to: 'end', lag: '2s'};
 
                 var read = test_utils.read(options, extra, deactivateAfter)
                 .then(function(result) {
@@ -34,10 +34,10 @@ describe('elastic source', function() {
                     return result;
                 });
 
-                return test_utils.write(points_to_write, {id: type})
+                return test_utils.write(points_to_write, {id: mode})
                 .then(function(result) {
                     expect(result.errors).deep.equal([]);
-                    return test_utils.verify_import(points_to_write, type);
+                    return test_utils.verify_import(points_to_write, mode);
                 })
                 .then(function() {
                     return read;
@@ -64,10 +64,10 @@ describe('elastic source', function() {
                     tags: {name: ['historical']}
                 });
 
-                return test_utils.write(historical, {id: type})
+                return test_utils.write(historical, {id: mode})
                     .then(function(result) {
                         expect(result.errors).deep.equal([]);
-                        return test_utils.verify_import(historical, type);
+                        return test_utils.verify_import(historical, mode);
                     })
                     .then(function() {
                         var live = generate_live_data();

--- a/test/write.spec.js
+++ b/test/write.spec.js
@@ -10,16 +10,16 @@ var check_juttle = juttle_test_utils.check_juttle;
 var modes = test_utils.modes;
 
 describe('write', function() {
-    modes.forEach(function(type) {
-        describe(type, function() {
+    modes.forEach(function(mode) {
+        describe(mode, function() {
             afterEach(function() {
                 elastic.clear_already_created_indices();
-                return test_utils.clear_data(type);
+                return test_utils.clear_data(mode);
             });
 
             it('fails to write a point with an _id field', function() {
                 var _id_point = {time: new Date().toISOString(), _id: 'this is broken now'};
-                return test_utils.write([_id_point], {id: type})
+                return test_utils.write([_id_point], {id: mode})
                     .then(function(result) {
                         expect(result.errors).match(/point rejected by Elasticsearch/);
                     });
@@ -31,11 +31,11 @@ describe('write', function() {
                     nest: {nested_key: 'nest'},
                     name: 'nest_haver'
                 };
-                return test_utils.write([nested_object], {id: type})
+                return test_utils.write([nested_object], {id: mode})
                     .then(function(result) {
                         expect(result.errors).deep.equal([]);
                         return retry(function() {
-                            return test_utils.search(type)
+                            return test_utils.search(mode)
                                 .then(function(result) {
                                     var hits = _.pluck(result.hits.hits, '_source');
                                     var imported = _.findWhere(hits, {name: 'nest_haver'});
@@ -49,19 +49,19 @@ describe('write', function() {
             it('writes with -chunkSize', function() {
                 var chunkSize = 5;
                 var points = test_utils.generate_sample_data({count: 100});
-                return test_utils.write(points, {id: type, chunkSize: chunkSize})
+                return test_utils.write(points, {id: mode, chunkSize: chunkSize})
                     .then(function(result) {
                         expect(result.errors).deep.equal([]);
                         var write = result.prog.graph.out_.default[0].proc.adapter;
                         expect(write.chunks_written).equal(points.length / chunkSize);
-                        return test_utils.verify_import(points, type);
+                        return test_utils.verify_import(points, mode);
                     });
             });
 
             it('writes a point with a moment', function() {
                 var time = new Date().toISOString();
                 var write_program = `emit -limit 1 | put fake_time = :${time}:` +
-                    ` | write elastic -id "${type}" -index "${test_utils.test_id}"`;
+                    ` | write elastic -id "${mode}" -index "${test_utils.test_id}"`;
 
                 return check_juttle({
                     program: write_program
@@ -69,7 +69,7 @@ describe('write', function() {
                 .then(function(result) {
                     expect(result.errors).deep.equal([]);
                     return retry(function() {
-                        return test_utils.read({id: type}, `fake_time = :${time}:`)
+                        return test_utils.read({id: mode}, `fake_time = :${time}:`)
                             .then(function(result) {
                                 expect(result.sinks.table[0].fake_time).equal(time);
                             });
@@ -81,7 +81,7 @@ describe('write', function() {
             it('writes a point with a duration', function() {
                 var time = '5 minutes';
                 var write_program = `emit -limit 1 | put duration = :${time}:` +
-                    ` | write elastic -id "${type}" -index "${test_utils.test_id}"`;
+                    ` | write elastic -id "${mode}" -index "${test_utils.test_id}"`;
 
                 return check_juttle({
                     program: write_program
@@ -89,7 +89,7 @@ describe('write', function() {
                 .then(function(result) {
                     expect(result.errors).deep.equal([]);
                     return retry(function() {
-                        return test_utils.read({id: type})
+                        return test_utils.read({id: mode})
                             .then(function(result) {
                                 expect(result.sinks.table.length).equal(1);
                                 expect(result.sinks.table[0].duration).equal('00:05:00.000');
@@ -97,7 +97,7 @@ describe('write', function() {
                     });
                 })
                 .then(function() {
-                    return test_utils.read({id: type}, `duration = :${time}:`);
+                    return test_utils.read({id: mode}, `duration = :${time}:`);
                 })
                 .then(function(result) {
                     expect(result.warnings).deep.equal([]);


### PR DESCRIPTION
We use type to refer to AWS/local as well as ES document type.
This is confusing, so use 'mode' for ES/local.
Finishes https://github.com/juttle/juttle-elastic-adapter/issues/88

@VladVega @dmehra 