### PR TITLE
filters: support filter on time

### DIFF
--- a/lib/filter-es-compiler.js
+++ b/lib/filter-es-compiler.js
@@ -31,12 +31,22 @@ class FilterESCompiler extends ASTVisitor {
         options = options || {};
         this.skipField = options.skipField;
         this.filtered_fields = [];
+        this.timeField = options.timeField;
     }
 
     compile(node) {
         var result = this.visit(node);
         result.filtered_fields = this.filtered_fields;
         return result;
+    }
+
+    _getNameForField(node) {
+        var name = node.name;
+        if (name === 'time' && this.timeField) {
+            return this.timeField;
+        }
+
+        return name;
     }
 
     visitNullLiteral(node) {
@@ -98,8 +108,9 @@ class FilterESCompiler extends ASTVisitor {
     }
 
     visitField(node) {
-        this.filtered_fields.push(node.name);
-        return node.name;
+        var name = this._getNameForField(node);
+        this.filtered_fields.push(name);
+        return name;
     }
 
     visitBinaryExpression(node) {

--- a/lib/read.js
+++ b/lib/read.js
@@ -25,7 +25,7 @@ class ReadElastic extends AdapterRead {
         this.filtered_fields = [];
         var filter_ast = params.filter_ast;
         if (filter_ast) {
-            var filter_es_compiler = new FilterESCompiler();
+            var filter_es_compiler = new FilterESCompiler({timeField: this.timeField});
             var result = filter_es_compiler.compile(filter_ast);
             this.es_filter = result.filter;
             this.filtered_fields = result.filtered_fields;

--- a/test/elastic-adapter.spec.js
+++ b/test/elastic-adapter.spec.js
@@ -101,6 +101,29 @@ juttle_test_utils.withAdapterAPI(function() {
                 });
             });
 
+            // depends on https://github.com/juttle/juttle/issues/483
+            it.skip('reads with an equality time filter on the actual time field', function() {
+                return test_utils.read({id: mode}, `*"@timestamp" = :${points[0].time}:`)
+                    .then(function(result) {
+                        var expected = points.filter(function(pt) {
+                            return pt.time === points[0].time;
+                        });
+
+                        test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
+                    });
+            });
+
+            it('reads with an equality time filter on the "time" field', function() {
+                return test_utils.read({id: mode}, `time = :${points[0].time}:`)
+                    .then(function(result) {
+                        var expected = points.filter(function(pt) {
+                            return pt.time === points[0].time;
+                        });
+
+                        test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
+                    });
+            });
+
             it('free text search', function() {
                 function test_fts(string) {
                     return test_utils.read({id: mode}, `"${string}"`)


### PR DESCRIPTION
Change the "time" field to the -timeField argument of the read
so that you can do read time=:5 minutes ago: etc. and it'll work

Fixes https://github.com/juttle/juttle-elastic-adapter/issues/83

@VladVega @demmer 