### PR TITLE
check_mapping: support nested fields

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -136,7 +136,22 @@ class ReadElastic extends AdapterRead {
     }
 
     _warn_if_missing(properties, field, index, type) {
-        if (properties && !properties.hasOwnProperty(field)) {
+        function _nested_access(object, fields) {
+            while (object && fields.length) {
+                var field = fields.shift();
+                if (object.hasOwnProperty(field)) {
+                    object = object[field].properties || object[field];
+                } else {
+                    return null;
+                }
+            }
+
+            return object;
+        }
+
+        var fields = field.split('.');
+
+        if (properties && !_nested_access(properties, fields)) {
             this.warn(`index "${index}" has no known property ` +
                 `"${field}" for type "${type}"`);
         }

--- a/test/nested-objects.spec.js
+++ b/test/nested-objects.spec.js
@@ -71,6 +71,7 @@ modes.forEach(function(mode) {
         it('optimized reduce by object field', function() {
             return test_utils.read({id: mode}, '| reduce count() by "nest.tag"')
                 .then(function(result) {
+                    expect(result.warnings).deep.equal([]);
                     var counts = _.countBy(points, function(pt) {
                         return pt.nest.tag;
                     });
@@ -82,6 +83,16 @@ modes.forEach(function(mode) {
                     var received = _.sortBy(result.sinks.table, 'nest.tag');
 
                     expect(expected).deep.equal(received);
+                });
+        });
+
+        it('optimized reduce by missing field warns', function() {
+            return test_utils.read({id: mode}, '| reduce count() by "nest.nobody"')
+                .then(function(result) {
+                    var warning = `index "${test_utils.test_id}" has no ` +
+                        `known property "nest.nobody" for type "event"`;
+                    expect(result.warnings).deep.equal([warning]);
+                    expect(result.sinks.table).deep.equal([ { count: 10, 'nest.nobody': null } ]);
                 });
         });
 


### PR DESCRIPTION
Currently we always warn if you do a nested property access
but instead we should deep-search the mapping for the property
fixes https://github.com/juttle/juttle-elastic-adapter/issues/111

@rlgomes @VladVega