### PR TITLE
read: don't apply limit globally

### DIFF
--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -6,8 +6,8 @@ var aggregation = require('./aggregation');
 var logger = JuttleAdapterAPI.getLogger('elastic-optimize');
 var reducerDefaultValue = JuttleAdapterAPI.runtime.reducerDefaultValue;
 var ALLOWED_REDUCE_OPTIONS = ['every', 'forget', 'groupby', 'on'];
-var DEFAULT_FETCH_SIZE = require('./query').DEFAULT_FETCH_SIZE;
 var utils = require('./utils');
+var DEFAULT_FETCH_SIZE = utils.DEFAULT_CONFIG.fetchSize;
 
 function _getFieldName(node) {
     return node.name;
@@ -73,7 +73,8 @@ var optimizer = {
             limit = Math.min(limit, optimization_info.limit);
         }
 
-        var read_fetch_size = graph.node_get_option(read, 'fetch_size') || DEFAULT_FETCH_SIZE;
+        var read_fetch_size = graph.node_get_option(read, 'fetchSize') || DEFAULT_FETCH_SIZE;
+
         if (limit > read_fetch_size) {
             logger.debug('optimization aborting -- cannot optimize tail limit over fetch size');
             return false;

--- a/lib/query.js
+++ b/lib/query.js
@@ -55,7 +55,7 @@ function fetcher(client, filter, query_start, query_end, options) {
     var idField = options.idField;
     var direction = options.direction || 'asc';
 
-    var fetch_size = options.fetch_size || DEFAULT_FETCH_SIZE;
+    var fetch_size = Math.min(options.fetch_size || DEFAULT_FETCH_SIZE, options.max_fetch_size);
     var deep_paging_limit = options.deep_paging_limit || DEFAULT_DEEP_PAGING_LIMIT;
     var should_execute_bridge_fetch = false;
     var last_seen_timestamp;

--- a/lib/query.js
+++ b/lib/query.js
@@ -49,41 +49,29 @@ function fetcher(client, filter, query_start, query_end, options) {
     var indices = options.indices;
     var type = options.type;
     var bridge_offset = 0;
-    var points_emitted_so_far = 0;
-    var limit = options.limit;
     var timeField = options.timeField;
     var idField = options.idField;
     var direction = options.direction || 'asc';
 
-    var fetch_size = Math.min(options.fetch_size || DEFAULT_FETCH_SIZE, options.max_fetch_size);
     var deep_paging_limit = options.deep_paging_limit || DEFAULT_DEEP_PAGING_LIMIT;
     var should_execute_bridge_fetch = false;
     var last_seen_timestamp;
 
-    if (limit === 0) {
-        return null_fetcher;
-    } else {
-        return query_fetcher;
-    }
+    return query_fetcher;
 
-    function query_fetcher() {
+    function query_fetcher(size) {
         return Promise.try(function() {
             if (should_execute_bridge_fetch) {
-                return bridge_fetch();
+                return bridge_fetch(size);
             } else {
-                var size = _get_body_size();
                 var body = make_body(filter, query_start, query_end, direction, null, size, timeField);
 
                 return common.search(client, indices, type, body)
                     .then(function(result) {
                         var processed = points_and_eof_from_es_result(result, body);
-                        return drop_last_time_stamp_and_maybe_bridge_fetch(processed);
+                        return drop_last_time_stamp_and_maybe_bridge_fetch(processed, size);
                     });
             }
-        })
-        .then(function(info) {
-            points_emitted_so_far += info.points.length;
-            return info;
         });
     }
 
@@ -94,12 +82,9 @@ function fetcher(client, filter, query_start, query_end, options) {
 
         var search_results = result.hits.hits;
         var all_points_read = (search_results.length + request_body.from === result.hits.total);
-        var limit_reached = (search_results.length === limit - points_emitted_so_far);
-
-        var eof = all_points_read || limit_reached;
         var full_page_read = (search_results.length === request_body.size);
 
-        if (!eof && !full_page_read) {
+        if (!all_points_read && !full_page_read) {
             var message = 'fetch error - results count mismatch , expected ' +
                 request_body.size + ', got ' + search_results.length;
             throw new Error(message);
@@ -115,27 +100,18 @@ function fetcher(client, filter, query_start, query_end, options) {
             total: result.hits.total,
             executed_query: _.extend({indices: indices}, request_body), // for tests
             points: points,
-            eof: eof
+            eof: all_points_read
         };
     }
 
-    function _get_body_size() {
-        if (typeof limit === 'number' && limit === limit) {
-            return Math.min(fetch_size, limit - points_emitted_so_far);
-        } else {
-            return fetch_size;
-        }
-    }
-
-    // if more than fetch_size events have the same timestamp, we do
+    // if more than fetchSize events have the same timestamp, we do
     // a "bridge fetch" which pages through all the points with that timestamp
-    function bridge_fetch() {
+    function bridge_fetch(size) {
         var bridge_time = new JuttleMoment(last_seen_timestamp);
 
         var time_filter = {term: {}};
         time_filter.term[timeField] = bridge_time.valueOf();
 
-        var size = _get_body_size();
         var body = make_body(filter, null, null, direction, time_filter, size, timeField);
         body.from = bridge_offset;
 
@@ -164,7 +140,7 @@ function fetcher(client, filter, query_start, query_end, options) {
     // with the last timestamp, triggering a bridge fetch if all the points
     // are simultaneous. This makes sure the next query, which starts
     // at the last timestamp, won't return any duplicates
-    function drop_last_time_stamp_and_maybe_bridge_fetch(processed) {
+    function drop_last_time_stamp_and_maybe_bridge_fetch(processed, size) {
         if (processed.eof) { return processed; }
         var last = _.last(processed.points);
         last_seen_timestamp = last && last.time;
@@ -176,7 +152,7 @@ function fetcher(client, filter, query_start, query_end, options) {
         if (non_simultaneous_points.length === 0 && processed.points.length !== 0) {
             should_execute_bridge_fetch = true;
             bridge_offset = 0;
-            return bridge_fetch();
+            return bridge_fetch(size);
         } else {
             query_start = new JuttleMoment(last_seen_timestamp);
             processed.points = non_simultaneous_points;
@@ -309,7 +285,7 @@ function _time_filter(from, to, timeField) {
 }
 
 function init(config) {
-    DEFAULT_FETCH_SIZE = config.fetch_size || DEFAULT_FETCH_SIZE;
+    DEFAULT_FETCH_SIZE = config.fetchSize || DEFAULT_FETCH_SIZE;
     DEFAULT_DEEP_PAGING_LIMIT = config.deep_paging_limit || DEFAULT_DEEP_PAGING_LIMIT;
 }
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -40,7 +40,7 @@ class ReadElastic extends AdapterRead {
             interval: this.interval,
             timeField: this.timeField,
             idField: this.idField,
-            limit: optimization_info.limit,
+            limit: this._calculate_limit(optimization_info.limit),
             direction: optimization_info.type === 'tail' ? 'desc' : 'asc',
             aggregations: optimization_info.aggregations
         };
@@ -58,7 +58,8 @@ class ReadElastic extends AdapterRead {
 
     static allowedOptions() {
         var elastic_options = ['id', 'timeField', 'type', 'idField', 'fetch_size',
-            'es_opts', 'deep_paging_limit', 'index', 'interval', 'optimize', 'indexInterval'];
+            'es_opts', 'deep_paging_limit', 'index', 'interval', 'optimize', 'indexInterval',
+            'queueSize'];
         return AdapterRead.commonOptions().concat(elastic_options);
     }
 
@@ -184,11 +185,11 @@ class ReadElastic extends AdapterRead {
     }
 
     _calculate_limit(limit) {
-        if (typeof this.es_opts.limit === 'number') {
-            return Math.min(limit, this.es_opts.limit);
+        if (typeof limit === 'number') {
+            return limit;
         }
 
-        return limit;
+        return Infinity;
     }
 
     warn(message) {
@@ -200,7 +201,6 @@ class ReadElastic extends AdapterRead {
         return this._check_options_vs_mapping(indices)
             .then(() => {
                 this.es_opts.indices = indices;
-                this.es_opts.limit = this._calculate_limit(limit);
                 if (!this.fetcher) {
                     this.fetcher = elastic.fetcher(this.id, this.es_filter, from, to, this.es_opts);
                 }

--- a/lib/read.js
+++ b/lib/read.js
@@ -20,6 +20,7 @@ class ReadElastic extends AdapterRead {
         this.timeField = options.timeField || this._default_config('timeField');
         this.type = options.type || this._default_config('readType');
         this.idField = options.idField || this._default_config('idField');
+        this.fetchSize = options.fetchSize || this._default_config('fetchSize');
 
         this._setup_index(options);
         this.filtered_fields = [];
@@ -35,29 +36,26 @@ class ReadElastic extends AdapterRead {
 
         var optimization_info = params && params.optimization_info || {};
 
+        this.head_or_tail_limit = this._calculate_limit(optimization_info.limit);
         this.es_opts = {
             type: this.type,
             interval: this.interval,
             timeField: this.timeField,
             idField: this.idField,
-            limit: this._calculate_limit(optimization_info.limit),
             direction: optimization_info.type === 'tail' ? 'desc' : 'asc',
             aggregations: optimization_info.aggregations
         };
-
-        if (options.fetch_size) {
-            this.es_opts.fetch_size = options.fetch_size;
-        }
 
         if (options.deep_paging_limit) {
             this.es_opts.deep_paging_limit = options.deep_paging_limit;
         }
 
         this.executed_queries = [];
+        this.points_emitted_so_far = 0;
     }
 
     static allowedOptions() {
-        var elastic_options = ['id', 'timeField', 'type', 'idField', 'fetch_size',
+        var elastic_options = ['id', 'timeField', 'type', 'idField', 'fetchSize',
             'es_opts', 'deep_paging_limit', 'index', 'interval', 'optimize', 'indexInterval',
             'queueSize'];
         return AdapterRead.commonOptions().concat(elastic_options);
@@ -192,6 +190,12 @@ class ReadElastic extends AdapterRead {
         return Infinity;
     }
 
+    _calculate_query_size(single_fetch_limit) {
+        var points_left_to_emit = this.head_or_tail_limit - this.points_emitted_so_far;
+
+        return Math.min(points_left_to_emit, this.fetchSize, single_fetch_limit);
+    }
+
     warn(message) {
         this.trigger('warning', new Error(message));
     }
@@ -205,14 +209,18 @@ class ReadElastic extends AdapterRead {
                     this.fetcher = elastic.fetcher(this.id, this.es_filter, from, to, this.es_opts);
                 }
 
-                return this.fetcher();
+                var num_points = this._calculate_query_size(limit);
+
+                return this.fetcher(num_points);
             })
             .then((result) => {
                 this._stash_executed_query(result);
                 this.fetcher = result.eof ? null : this.fetcher;
+                this.points_emitted_so_far += result.points.length;
+                var eof = result.eof || (this.points_emitted_so_far === this.head_or_tail_limit);
                 return {
                     points: toNative(result.points),
-                    readEnd: result.eof ? to : null
+                    readEnd: eof ? to : null
                 };
             });
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,6 +11,7 @@ var DEFAULT_CONFIG = {
     concurrency: 10,
     chunkSize: 1024,
     writeType: 'event',
+    fetchSize: 10000,
     readType: ''
 };
 

--- a/test/elastic-adapter-limits.spec.js
+++ b/test/elastic-adapter-limits.spec.js
@@ -40,7 +40,7 @@ describe('elastic source limits', function() {
             });
 
             it('errors if you try to read too many simultaneous points', function() {
-                var extra = '-fetch_size 2 -deep_paging_limit 3';
+                var extra = '-fetchSize 2 -deep_paging_limit 3';
                 return test_utils.read({id: mode}, extra)
                 .then(function(result) {
                     expect(result.errors).deep.equal([ 'Cannot fetch more than 3 points with the same timestamp' ]);
@@ -48,22 +48,22 @@ describe('elastic source limits', function() {
             });
 
             it('enforces head across multiple fetches', function() {
-                var extra = '-fetch_size 2 | head 3';
+                var extra = '-fetchSize 2 | head 3';
                 return test_utils.read({id: mode}, extra)
                 .then(function(result) {
                     var expected = points.slice(0, 3);
                     test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
-                    expect(result.prog.graph.adapter.es_opts.limit).equal(3);
+                    expect(result.prog.graph.adapter.executed_queries[0].size).equal(2);
                 });
             });
 
             it('doesn\'t optimize tail in excess of fetch size', function() {
-                var extra = '-fetch_size 2 | tail 8';
+                var extra = '-fetchSize 2 | tail 8';
                 return test_utils.read({id: mode}, extra)
                 .then(function(result) {
                     var expected = _.last(points, 8);
                     test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
-                    expect(result.prog.graph.adapter.es_opts.limit).equal(Infinity);
+                    expect(result.prog.graph.adapter.executed_queries[0].size).equal(2);
                 });
             });
 
@@ -97,7 +97,7 @@ describe('elastic source limits', function() {
             });
 
             it('unoptimized tail over multiple fetches', function() {
-                return test_utils.read({id: mode, fetch_size: 2}, ' | tail 8')
+                return test_utils.read({id: mode, fetchSize: 2}, ' | tail 8')
                     .then(function(result) {
                         var expected = _.last(points, 8);
                         test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
@@ -105,7 +105,7 @@ describe('elastic source limits', function() {
             });
 
             it('unoptimized tail with small queueSize', function() {
-                return test_utils.read({id: mode, fetch_size: 3, queueSize: 3, optimize: false}, ' | tail 8')
+                return test_utils.read({id: mode, fetchSize: 3, queueSize: 3, optimize: false}, ' | tail 8')
                     .then(function(result) {
                         var expected = _.last(points, 8);
                         test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');

--- a/test/elastic-adapter-limits.spec.js
+++ b/test/elastic-adapter-limits.spec.js
@@ -63,7 +63,7 @@ describe('elastic source limits', function() {
                 .then(function(result) {
                     var expected = _.last(points, 8);
                     test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
-                    expect(result.prog.graph.adapter.es_opts.limit).equal(100000);
+                    expect(result.prog.graph.adapter.es_opts.limit).equal(Infinity);
                 });
             });
 
@@ -94,6 +94,30 @@ describe('elastic source limits', function() {
                 .finally(function() {
                     return set_window(10000);
                 });
+            });
+
+            it('unoptimized tail over multiple fetches', function() {
+                return test_utils.read({id: mode, fetch_size: 2}, ' | tail 8')
+                    .then(function(result) {
+                        var expected = _.last(points, 8);
+                        test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
+                    });
+            });
+
+            it('unoptimized tail with small queueSize', function() {
+                return test_utils.read({id: mode, fetch_size: 3, queueSize: 3, optimize: false}, ' | tail 8')
+                    .then(function(result) {
+                        var expected = _.last(points, 8);
+                        test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'bytes');
+                    });
+            });
+
+            it('queueSize becomes fetchSize when it\'s smaller', function() {
+                return test_utils.read({id: mode, queueSize: 2})
+                    .then(function(result) {
+                        expect(result.prog.graph.adapter.executed_queries[0].size).equal(2);
+                        test_utils.check_result_vs_expected_sorting_by(result.sinks.table, points, 'bytes');
+                    });
             });
         });
     });

--- a/test/optimization.spec.js
+++ b/test/optimization.spec.js
@@ -54,7 +54,6 @@ juttle_test_utils.withAdapterAPI(function() {
             });
 
             function expect_graph_has_limit(graph, limit) {
-                expect(graph.adapter.es_opts.limit).equal(limit);
                 expect(graph.adapter.executed_queries[0].size).equal(limit);
             }
 
@@ -107,7 +106,6 @@ juttle_test_utils.withAdapterAPI(function() {
                     return test_utils.read({id: type}, '| head 0')
                     .then(function(result) {
                         expect(result.sinks.table).deep.equal([]);
-                        expect(result.prog.graph.adapter.es_opts.limit).equal(0);
                     });
                 });
             });
@@ -156,7 +154,6 @@ juttle_test_utils.withAdapterAPI(function() {
                     return test_utils.read({id: type}, '| tail 0')
                     .then(function(result) {
                         expect(result.sinks.table).deep.equal([]);
-                        expect(result.prog.graph.adapter.executed_queries.length).equal(0);
                     });
                 });
 


### PR DESCRIPTION
`read elastic` uses the same logic for `limit` as it does for `head` and
`tail`, so across any number of fetches it won't return more than a
total of `limit` points. This is not the right way to enforce `limit`,
which only applies to each individual call to the `read()` function.
The right way to enforce `limit` is to make it an upper bound on 
`fetch_size`, since each call to `read()` performs one fetch.

Fixes https://github.com/juttle/juttle-elastic-adapter/issues/115
Fixes https://github.com/juttle/juttle-elastic-adapter/issues/116

@VladVega @demmer 