### PR TITLE
aggregations: fix missing index

### DIFF
--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -166,12 +166,12 @@ function _time_sort(points) {
 }
 
 function _aggregation_values(aggregation_result, count, info) {
-    var pt = {};
+    var pt = _.clone(info.empty_result);
     var aggr_names = info.aggr_names || [];
     aggr_names.forEach(function(op) {
         var key = op[0];
         var reducer = op[1];
-        if (aggregation_result.hasOwnProperty(key)) {
+        if (_.has(aggregation_result, key)) {
             if (reducer === 'stdev') {
                 pt[key] = aggregation_result[key].std_deviation;
             } else {
@@ -209,6 +209,7 @@ function points_from_grouped_response(response, info) {
     var points = [];
     var is_date_histogram = _is_date_histogram(response.aggregations);
     function points_from_group(aggregation, fields, point_base) {
+        if (!aggregation) { return; }
         var field = fields.shift();
         var bucket = aggregation[field];
         _assert_nonempty_group(bucket, field);

--- a/test/optimization.spec.js
+++ b/test/optimization.spec.js
@@ -193,6 +193,19 @@ juttle_test_utils.withAdapterAPI(function() {
                     });
                 });
 
+                it('gracefully fails if there are no matching indices', function() {
+                    var extra = '| reduce avg(bytes)';
+                    return test_utils.check_optimization(start, end, type, extra, {
+                        index: 'no_such_index'
+                    })
+                    .then(function() {
+                        var grouped_extra = '| reduce avg(bytes) by clientip';
+                        return test_utils.check_optimization(start, end, type, grouped_extra, {
+                            index: 'no_such_index'
+                        });
+                    });
+                });
+
                 it('optimizes count(field)', function() {
                     return test_utils.read({id: type}, '| reduce count(clientip)')
                     .then(function(result) {


### PR DESCRIPTION
When you do an optimized query against a non-existent index,
the Elastic response doesn't have an aggregations key, so we
crash when we call .hasOwnProperty on response.aggregations. We
already calculate the empty_result thing we're supposed to return
in this case, so let's actually use it.

Fixes https://github.com/juttle/juttle-elastic-adapter/issues/120

@demmer @VladVega 