### PR TITLE
quiet down the get mapping warning when there's no matching index

### DIFF
--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -102,7 +102,8 @@ function mapping_for_id(id, index, type) {
     var instance = _instance_for_id(id);
     return _get_mapping(instance.client, index, type)
         .catch(function(err) {
-            logger.warn('error getting ES mapping', err);
+            logger.warn(`error getting ES mapping for ${index}/${type || "*"}:`,
+                err.statusCode === 404 ? 'no matching index' : err);
             return {};
         });
 }


### PR DESCRIPTION
When warning about failing to get the mapping for a given index/type,
print a nicer message if the error is just that the index isn't there.