### PR TITLE
read: use right indices in _check_options_vs_mapping

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -36,7 +36,6 @@ class ReadElastic extends AdapterRead {
         var optimization_info = params && params.optimization_info || {};
 
         this.es_opts = {
-            indices: this.index,
             type: this.type,
             interval: this.interval,
             timeField: this.timeField,
@@ -90,11 +89,11 @@ class ReadElastic extends AdapterRead {
         return utils.default_config_property_for_id(this.id, property);
     }
 
-    _check_options_vs_mapping() {
+    _check_options_vs_mapping(indices) {
         if (this.checked_options_vs_mapping_already) { return Promise.resolve(); }
         this.checked_options_vs_mapping_already = true;
 
-        return elastic.mapping_for_id(this.id, this.index, this.type)
+        return elastic.mapping_for_id(this.id, indices, this.type)
             .then((mapping) => {
                 this._warn_if_no_index_or_type(mapping);
                 _.each(mapping, (mapping_object, index) => {
@@ -197,9 +196,10 @@ class ReadElastic extends AdapterRead {
     }
 
     read(from, to, limit, state) {
-        return this._check_options_vs_mapping()
+        var indices = common.get_indices(from, to, this.index, this.interval);
+        return this._check_options_vs_mapping(indices)
             .then(() => {
-                this.es_opts.indices = common.get_indices(from, to, this.index, this.interval);
+                this.es_opts.indices = indices;
                 this.es_opts.limit = this._calculate_limit(limit);
                 if (!this.fetcher) {
                     this.fetcher = elastic.fetcher(this.id, this.es_filter, from, to, this.es_opts);

--- a/test/index-intervals.spec.js
+++ b/test/index-intervals.spec.js
@@ -80,6 +80,7 @@ modes.forEach(function(mode) {
                 return test_utils.read({id: mode, from: from, to: to, index: index, indexInterval: interval});
             })
             .then(function(result) {
+                expect(result.warnings).deep.equal([]);
                 test_utils.check_result_vs_expected_sorting_by(result.sinks.table, points, 'bytes');
                 return test_utils.read({id: mode, from: before_any_data, to: from, index: index, indexInterval: interval});
             })


### PR DESCRIPTION
Currently we check the mapping for this.index, which isn't
an actual index if we're using an indexInterval, only a prefix.
Let's check the mapping for the actual indices we're querying.

Fixes https://github.com/juttle/juttle-elastic-adapter/issues/124

@demmer @VladVega 