### PR TITLE
check_mapping: consider .fields

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -98,6 +98,7 @@ class ReadElastic extends AdapterRead {
                 _.each(mapping, (mapping_object, index) => {
                     var index_mapping = mapping_object.mappings || {};
                     _.each(index_mapping, (props_object, type) => {
+                        if (type === '_default_') { return; }
                         var properties = props_object.properties;
                         this._warn_if_missing(properties, this.timeField, index, type);
 
@@ -138,7 +139,7 @@ class ReadElastic extends AdapterRead {
             while (object && fields.length) {
                 var field = fields.shift();
                 if (object.hasOwnProperty(field)) {
-                    object = object[field].properties || object[field];
+                    object = object[field].properties || object[field].fields || object[field];
                 } else {
                     return null;
                 }

--- a/test/elastic-test-utils.js
+++ b/test/elastic-test-utils.js
@@ -350,8 +350,8 @@ function get_mapping(mode) {
         });
 }
 
-function create_index(mode, index) {
-    var options = {index: index};
+function create_index(mode, index, body) {
+    var options = {index: index, body: body};
     var client = _client_for_mode(mode);
     return client.indices.createAsync(options);
 }

--- a/test/logstash-mapping.json
+++ b/test/logstash-mapping.json
@@ -1,0 +1,41 @@
+{
+    "mappings": {
+        "_default_": {
+            "dynamic_templates": [
+                {
+                    "message_field": {
+                        "mapping": {
+                            "index": "analyzed",
+                            "omit_norms": true,
+                            "type": "string"
+                        },
+                        "match": "message",
+                        "match_mapping_type": "string"
+                    }
+                },
+                {
+                    "string_fields": {
+                        "mapping": {
+                            "index": "analyzed",
+                            "omit_norms": true,
+                            "type": "string",
+                            "fields": {
+                                "raw": {
+                                    "ignore_above": 256,
+                                    "index": "not_analyzed",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "match": "*",
+                        "match_mapping_type": "string"
+                    }
+                }
+            ],
+            "_all": {
+                "enabled": true,
+                "omit_norms": true
+            }
+        }
+    }
+}

--- a/test/logstash-mapping.spec.js
+++ b/test/logstash-mapping.spec.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var _ = require('underscore');
+var expect = require('chai').expect;
+
+var test_utils = require('./elastic-test-utils');
+var points = require('./apache-sample');
+var LOGSTASH_MAPPING = require('./logstash-mapping');
+var index_name = 'logstash_mapping_test' + test_utils.test_id;
+
+var modes = test_utils.modes;
+modes.forEach(function(mode) {
+    describe(`logstash mapping -- ${mode}`, function() {
+        before(function() {
+            return test_utils.create_index(mode, index_name, LOGSTASH_MAPPING)
+                .then(function() {
+                    return test_utils.write(points, {id: mode, index: index_name});
+                })
+                .then(function(result) {
+                    expect(result.errors).deep.equal([]);
+                    return test_utils.verify_import(points, mode, index_name);
+                });
+        });
+
+        after(function() {
+            return test_utils.clear_data(mode, index_name);
+        });
+
+        it('reads data ingested by logstash', function() {
+            return test_utils.read({id: mode, index: index_name})
+                .then(function(result) {
+                    test_utils.check_result_vs_expected_sorting_by(result.sinks.table, points, 'bytes');
+                });
+        });
+
+        it('reduce by without warnings', function() {
+            return test_utils.read({id: mode, index: index_name}, '| reduce count() by "clientip.raw"')
+            .then(function(result) {
+                expect(result.warnings).deep.equal([]);
+                var expected = _.chain(points).countBy('clientip').map(function(count, clientip) {
+                    return {
+                        'clientip.raw': clientip,
+                        count: count
+                    };
+                }).value();
+
+                test_utils.check_result_vs_expected_sorting_by(result.sinks.table, expected, 'clientip.raw');
+            });
+        });
+    });
+});


### PR DESCRIPTION
When Logstash stores points, it creates a mapping where the .raw
is in the .fields. Currently, our mapping only looks in .properties.
Let's look in .fields too.

Also, let's ignore `_default_` which isn't a real type.

Fixes https://github.com/juttle/juttle-elastic-adapter/issues/126

@VladVega @demmer 