### PR TITLE
read: restore aggregations

### DIFF
--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -149,9 +149,11 @@ function remove_field(aggr, name) {
 
     return {
         es_aggr: new_es_aggr,
+        original_es_aggr: aggr.es_aggr,
         empty_result: aggr.empty_result,
         aggr_names: aggr.aggr_names,
         grouping: grouping,
+        original_grouping: aggr.grouping,
         count: aggr.count,
         empty_fields: empty_fields
     };

--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -172,11 +172,13 @@ var optimizer = {
             type: 'reduce',
             aggregations: {
                 es_aggr: aggrs,
+                original_es_aggr: aggrs,
                 aggr_names: aggr_names,
                 count: count_name,
                 empty_result: empty_result,
                 empty_fields: [],
                 grouping: groupby || [],
+                original_grouping: groupby || [],
                 reduce_every: every,
                 reduce_on: on
             }

--- a/lib/query.js
+++ b/lib/query.js
@@ -207,6 +207,8 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
                 });
             }
 
+            restore_aggregations();
+
             return {
                 eof: buckets.length === 1, // last bucket is exclusive
                 executed_query: _.extend({indices: indices}, query_body), // for tests
@@ -221,6 +223,14 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
             buckets.unshift(from);
             return fetcher();
         });
+    }
+
+    // if we make some changes to our aggregations, such as aggregation.remove_field,
+    // undo them here so that in case of reduce -every with multiple batches
+    // we'll perform the original aggregation
+    function restore_aggregations() {
+        aggregations.grouping = aggregations.original_grouping;
+        aggregations.es_aggr = aggregations.original_es_aggr;
     }
 
     function get_batch_offset_as_duration(every_duration) {

--- a/test/optimization.spec.js
+++ b/test/optimization.spec.js
@@ -441,6 +441,13 @@ juttle_test_utils.withAdapterAPI(function() {
                     return test_utils.check_optimization('10 years ago', 'now', type, extra);
                 });
 
+                it('optimizes reduce -every by with a lot of buckets', function() {
+                    var extra = '| reduce -every :h: count() by clientip';
+                    return test_utils.check_optimization('5 years ago', 'now', type, extra, {
+                        massage: sortBy('clientip')
+                    });
+                });
+
                 it('doesn\'t optimize reduce -acc true', function() {
                     return test_utils.read({from: start, to: end, id: type}, '| reduce -every :s: -acc true by clientip')
                         .then(function(result) {


### PR DESCRIPTION
If reduce by has a missing field, we take the field out of the aggregation.
But if it's reduce by -every, we need to put it back for future batches.

Fixes https://github.com/juttle/juttle-elastic-adapter/issues/129

@demmer @VladVega