### PR TITLE
read: restore aggregations

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -217,9 +217,14 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
             // our scripted aggregation will fail if we try to group
             // by a non-existent field.  when this happens, remove
             // the non-existent field and re-run the aggregation.
+            var orig = _.clone(aggregations);
             aggregations = aggregation.remove_field(aggregations, ex.name);
             buckets.unshift(from);
-            return fetcher();
+            return fetcher()
+            .then((result) => {
+                aggregations = orig;
+                return result;
+            });
         });
     }
 

--- a/test/optimization.spec.js
+++ b/test/optimization.spec.js
@@ -441,6 +441,13 @@ juttle_test_utils.withAdapterAPI(function() {
                     return test_utils.check_optimization('10 years ago', 'now', type, extra);
                 });
 
+                it('optimizes reduce -every by with a lot of buckets', function() {
+                    var extra = '| reduce -every :h: count() by clientip';
+                    return test_utils.check_optimization('5 years ago', 'now', type, extra, {
+                        massage: sortBy('clientip')
+                    });
+                });
+
                 it('doesn\'t optimize reduce -acc true', function() {
                     return test_utils.read({from: start, to: end, id: type}, '| reduce -every :s: -acc true by clientip')
                         .then(function(result) {


### PR DESCRIPTION
If reduce by has a missing field, we take the field out of the aggregation.
But if it's reduce by -every, we need to put it back for future batches.

Fixes #129 
Rework of #130