### PR TITLE
read: wrap runtime errors in a juttle error

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -6,6 +6,7 @@ var _ = require('underscore');
 var AdapterRead = JuttleAdapterAPI.AdapterRead;
 var JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
 var toNative = JuttleAdapterAPI.runtime.toNative;
+var errors = JuttleAdapterAPI.errors;
 
 var FilterESCompiler = require('./filter-es-compiler');
 var elastic = require('./elastic');
@@ -223,6 +224,10 @@ class ReadElastic extends AdapterRead {
                     points: toNative(result.points),
                     readEnd: eof ? to : null
                 };
+            })
+            .catch((err) => {
+                this.logger.debug('internal error', err.stack);
+                throw new errors.RuntimeError(err.message, 'ELASTIC-ADAPTER-RUNTIME-ERROR', {});
             });
     }
 }


### PR DESCRIPTION
The change in Juttle 0.7.1 to wrap all vanilla JS errors coming from read in an internal error changed the test expectations since the error messages now included "internal error".

Instead catch the errors in the adapter itself and wrap them in a proper runtime error with an adapter-specific error code.