### PR TITLE
use Error subclassing instead of extendable-base

### DIFF
--- a/lib/es-errors.js
+++ b/lib/es-errors.js
@@ -1,13 +1,37 @@
-var util = require('util');
-var Base = require('extendable-base');
+'use strict';
 
-var MissingIndex = Base.inherits(Error, {});
-var NewIndex = Base.inherits(Error, {});
-var MissingField = Base.inherits(Error, {
-    initialize: function(name) {
-        this.name = name;
+var util = require('util');
+
+class MissingIndex extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'MissingIndex';
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
     }
-});
+}
+
+class NewIndex extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'NewIndex';
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+    }
+}
+
+class MissingField extends Error{
+    constructor(field) {
+        super(field);
+        this.name = 'MissingField';
+        this.field = field;
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+    }
+}
 
 var _MISSING_FIELD_PATTERN = /No field found for \[([^\]]+)\] in mapping/;
 var _GROOVY_PATTERN = /groovy_script_execution_exception/;

--- a/lib/query.js
+++ b/lib/query.js
@@ -218,7 +218,7 @@ function aggregation_fetcher(client, filter, query_start, query_end, options) {
             // by a non-existent field.  when this happens, remove
             // the non-existent field and re-run the aggregation.
             var orig = _.clone(aggregations);
-            aggregations = aggregation.remove_field(aggregations, ex.name);
+            aggregations = aggregation.remove_field(aggregations, ex.field);
             buckets.unshift(from);
             return fetcher()
             .then((result) => {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "concurrency-master": "^0.1.0",
     "current-week-number": "^1.0.7",
     "elasticsearch": "^10.0.1",
-    "extendable-base": "^0.3.1",
     "request": "^2.44.0",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
Get rid of the extendable-base dependency by crafting proper `Error` subclasses.

@davidvgalbraith 